### PR TITLE
feat: cache location claim in indexing service

### DIFF
--- a/pkg/service/blobs/options.go
+++ b/pkg/service/blobs/options.go
@@ -1,0 +1,15 @@
+package blobs
+
+import logging "github.com/ipfs/go-log/v2"
+
+type options struct{}
+
+type Option func(*options) error
+
+// WithLogLevel changes the log level for the claims subsystem.
+func WithLogLevel(level string) Option {
+	return func(c *options) error {
+		logging.SetLogLevel("blobs", level)
+		return nil
+	}
+}

--- a/pkg/service/blobs/server.go
+++ b/pkg/service/blobs/server.go
@@ -106,7 +106,7 @@ func NewBlobPutHandler(presigner presigner.RequestPresigner, allocs allocationst
 			return
 		}
 
-		log.Infof("found %d allocations for write to: z%s", len(results), digest.B58String())
+		log.Infof("Found %d allocations for write to: z%s", len(results), digest.B58String())
 
 		_, err = blobs.Get(r.Context(), digest)
 		if err == nil {

--- a/pkg/service/blobs/service.go
+++ b/pkg/service/blobs/service.go
@@ -39,7 +39,15 @@ func (b *BlobService) Store() blobstore.Blobstore {
 
 var _ Blobs = (*BlobService)(nil)
 
-func New(id principal.Signer, blobStore blobstore.Blobstore, allocsDatastore datastore.Datastore, publicURL url.URL) (*BlobService, error) {
+func New(id principal.Signer, blobStore blobstore.Blobstore, allocsDatastore datastore.Datastore, publicURL url.URL, opts ...Option) (*BlobService, error) {
+	o := &options{}
+	for _, opt := range opts {
+		err := opt(o)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	allocStore, err := allocationstore.NewDsAllocationStore(allocsDatastore)
 	if err != nil {
 		return nil, err

--- a/pkg/service/claims/options.go
+++ b/pkg/service/claims/options.go
@@ -1,4 +1,4 @@
-package publisher
+package claims
 
 import (
 	"net/url"
@@ -18,25 +18,27 @@ type options struct {
 
 type Option func(*options) error
 
-// WithDirectAnnounce sets indexer URLs to send direct HTTP announcements to.
-func WithDirectAnnounce(announceURLs ...url.URL) Option {
+// WithPublisherDirectAnnounce sets indexer URLs to send direct HTTP
+// announcements to.
+func WithPublisherDirectAnnounce(announceURLs ...url.URL) Option {
 	return func(o *options) error {
 		o.announceURLs = append(o.announceURLs, announceURLs...)
 		return nil
 	}
 }
 
-// WithIndexingService sets the client connection to the indexing UCAN service.
-func WithIndexingService(conn client.Connection) Option {
+// WithPublisherIndexingService sets the client connection to the indexing UCAN
+// service.
+func WithPublisherIndexingService(conn client.Connection) Option {
 	return func(opts *options) error {
 		opts.indexingService = conn
 		return nil
 	}
 }
 
-// WithIndexingServiceConfig configures UCAN service invocation details for
-// communicating with the indexing service.
-func WithIndexingServiceConfig(serviceDID ucan.Principal, serviceURL url.URL) Option {
+// WithPublisherIndexingServiceConfig configures UCAN service invocation details
+// for communicating with the indexing service.
+func WithPublisherIndexingServiceConfig(serviceDID ucan.Principal, serviceURL url.URL) Option {
 	return func(opts *options) error {
 		channel := http.NewHTTPChannel(&serviceURL)
 		conn, err := client.NewConnection(serviceDID, channel)
@@ -48,19 +50,19 @@ func WithIndexingServiceConfig(serviceDID ucan.Principal, serviceURL url.URL) Op
 	}
 }
 
-// WithIndexingServiceProof configures proofs for UCAN invocations to the
-// indexing service.
-func WithIndexingServiceProof(proof ...delegation.Proof) Option {
+// WithPublisherIndexingServiceProof configures proofs for UCAN invocations to
+// the indexing service.
+func WithPublisherIndexingServiceProof(proof ...delegation.Proof) Option {
 	return func(opts *options) error {
 		opts.indexingServiceProofs = proof
 		return nil
 	}
 }
 
-// WithLogLevel changes the log level for the publisher subsystem.
+// WithLogLevel changes the log level for the claims subsystem.
 func WithLogLevel(level string) Option {
 	return func(c *options) error {
-		logging.SetLogLevel("publisher", level)
+		logging.SetLogLevel("claims", level)
 		return nil
 	}
 }

--- a/pkg/service/claims/server.go
+++ b/pkg/service/claims/server.go
@@ -13,7 +13,7 @@ import (
 	"github.com/storacha/storage/pkg/store/claimstore"
 )
 
-var log = logging.Logger("blobs")
+var log = logging.Logger("claims")
 
 type Server struct {
 	claims claimstore.ClaimStore

--- a/pkg/service/publisher/publisher.go
+++ b/pkg/service/publisher/publisher.go
@@ -21,7 +21,6 @@ import (
 	"github.com/storacha/go-ucanto/core/invocation"
 	"github.com/storacha/go-ucanto/core/receipt"
 	"github.com/storacha/go-ucanto/core/result"
-	"github.com/storacha/go-ucanto/did"
 	"github.com/storacha/go-ucanto/principal"
 	ipnipub "github.com/storacha/ipni-publisher/pkg/publisher"
 	"github.com/storacha/ipni-publisher/pkg/store"
@@ -30,12 +29,6 @@ import (
 )
 
 var log = logging.Logger("publisher")
-
-var (
-	AnnounceURL, _        = url.Parse("https://cid.contact/announce")
-	IndexingServiceDID, _ = did.Parse("did:web:indexer.storacha.network")
-	IndexingServiceURL, _ = url.Parse("https://indexer.storacha.network")
-)
 
 type PublisherService struct {
 	id                    principal.Signer

--- a/pkg/service/publisher/publisher.go
+++ b/pkg/service/publisher/publisher.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"strings"
 
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
@@ -15,22 +14,36 @@ import (
 	"github.com/multiformats/go-multiaddr"
 	"github.com/multiformats/go-multihash"
 	"github.com/storacha/go-capabilities/pkg/assert"
+	"github.com/storacha/go-capabilities/pkg/claim"
 	"github.com/storacha/go-metadata"
+	"github.com/storacha/go-ucanto/client"
 	"github.com/storacha/go-ucanto/core/delegation"
+	"github.com/storacha/go-ucanto/core/invocation"
+	"github.com/storacha/go-ucanto/core/receipt"
+	"github.com/storacha/go-ucanto/core/result"
+	"github.com/storacha/go-ucanto/did"
+	"github.com/storacha/go-ucanto/principal"
 	ipnipub "github.com/storacha/ipni-publisher/pkg/publisher"
 	"github.com/storacha/ipni-publisher/pkg/store"
+	"github.com/storacha/storage/pkg/capability"
 	"github.com/storacha/storage/pkg/service/publisher/advertisement"
 )
 
-const claimPattern = "{claim}"
-
 var log = logging.Logger("publisher")
 
+var (
+	AnnounceURL, _        = url.Parse("https://cid.contact/announce")
+	IndexingServiceDID, _ = did.Parse("did:web:indexer.storacha.network")
+	IndexingServiceURL, _ = url.Parse("https://indexer.storacha.network")
+)
+
 type PublisherService struct {
-	store            store.PublisherStore
-	publisher        ipnipub.Publisher
-	peerInfo         peer.AddrInfo
-	claimPathPattern string
+	id                    principal.Signer
+	store                 store.PublisherStore
+	publisher             ipnipub.Publisher
+	provider              peer.AddrInfo
+	indexingService       client.Connection
+	indexingServiceProofs delegation.Proofs
 }
 
 func (pub *PublisherService) Store() store.PublisherStore {
@@ -41,23 +54,25 @@ func (pub *PublisherService) Publish(ctx context.Context, claim delegation.Deleg
 	ability := claim.Capabilities()[0].Can()
 	switch ability {
 	case assert.LocationAbility:
-		return PublishLocationCommitment(ctx, pub.publisher, pub.peerInfo, pub.claimPathPattern, claim)
+		err := PublishLocationCommitment(ctx, pub.publisher, pub.provider, claim)
+		if err != nil {
+			return err
+		}
+		return CacheClaim(ctx, pub.id, pub.indexingService, pub.indexingServiceProofs, claim, pub.provider.Addrs)
 	default:
 		return fmt.Errorf("unknown claim: %s", ability)
 	}
 }
 
-func PublishLocationCommitment(ctx context.Context, publisher ipnipub.Publisher, peerInfo peer.AddrInfo, pathPattern string, claim delegation.Delegation) error {
-	provider := peer.AddrInfo{ID: peerInfo.ID}
-	suffix, err := multiaddr.NewMultiaddr("/http-path/" + url.PathEscape(pathPattern))
-	if err != nil {
-		return fmt.Errorf("building http-path suffix: %w", err)
-	}
-	for _, addr := range peerInfo.Addrs {
-		provider.Addrs = append(provider.Addrs, multiaddr.Join(addr, suffix))
-	}
+func PublishLocationCommitment(
+	ctx context.Context,
+	publisher ipnipub.Publisher,
+	provider peer.AddrInfo,
+	locationCommitment delegation.Delegation,
+) error {
+	log := log.With("claim", locationCommitment.Link())
 
-	cap := claim.Capabilities()[0]
+	cap := locationCommitment.Capabilities()[0]
 	nb, rerr := assert.LocationCaveatsReader.Read(cap.Nb())
 	if rerr != nil {
 		return fmt.Errorf("reading location commitment data: %w", rerr)
@@ -70,13 +85,13 @@ func PublishLocationCommitment(ctx context.Context, publisher ipnipub.Publisher,
 	}
 
 	var exp int
-	if claim.Expiration() != nil {
-		exp = *claim.Expiration()
+	if locationCommitment.Expiration() != nil {
+		exp = *locationCommitment.Expiration()
 	}
 
 	meta := metadata.MetadataContext.New(
 		&metadata.LocationCommitmentMetadata{
-			Claim:      asCID(claim.Link()),
+			Claim:      asCID(locationCommitment.Link()),
 			Expiration: int64(exp),
 		},
 	)
@@ -86,10 +101,88 @@ func PublishLocationCommitment(ctx context.Context, publisher ipnipub.Publisher,
 		return fmt.Errorf("publishing claim: %w", err)
 	}
 
-	log.Infof("published advertisement for location commitment: %s", adlink)
-
-	// TODO: cache in indexing-service
+	log.Infof("Published advertisement: %s", adlink)
 	return nil
+}
+
+var claimCacheReceiptSchema = []byte(`
+	type Result union {
+		| Unit "ok"
+		| Any "error"
+	} representation keyed
+
+	type Unit struct {}
+`)
+var claimCacheReceiptReader, _ = receipt.NewReceiptReader[capability.Unit, ipld.Node](claimCacheReceiptSchema)
+
+func CacheClaim(
+	ctx context.Context,
+	id principal.Signer,
+	indexingService client.Connection,
+	invocationProofs delegation.Proofs,
+	clm delegation.Delegation,
+	providerAddresses []multiaddr.Multiaddr,
+) error {
+	log := log.With("claim", clm.Link())
+
+	if indexingService == nil {
+		log.Warnf("Cannot cache claim - indexing service is not configured")
+		return nil
+	}
+
+	inv, err := claim.Cache.Invoke(
+		id,
+		indexingService.ID(),
+		indexingService.ID().DID().String(),
+		claim.CacheCaveats{
+			Claim:    clm.Link(),
+			Provider: claim.Provider{Addresses: providerAddresses},
+		},
+		delegation.WithProof(invocationProofs...),
+	)
+	if err != nil {
+		return fmt.Errorf("creating invocation: %w", err)
+	}
+
+	res, err := client.Execute([]invocation.Invocation{inv}, indexingService)
+	if err != nil {
+		return fmt.Errorf("executing invocation: %w", err)
+	}
+
+	rcptLink, ok := res.Get(inv.Link())
+	if !ok {
+		return fmt.Errorf("getting receipt link: %w", err)
+	}
+	rcpt, err := claimCacheReceiptReader.Read(rcptLink, res.Blocks())
+	if err != nil {
+		return fmt.Errorf("reading receipt: %w", err)
+	}
+	return result.MatchResultR1(
+		rcpt.Out(),
+		func(ok capability.Unit) error {
+			log.Info("Cached location commitment with indexing service")
+			return nil
+		},
+		func(node ipld.Node) error {
+			name := "UnknownError"
+			message := "claim/cache invocation failed"
+			nn, err := node.LookupByString("name")
+			if err == nil {
+				n, err := nn.AsString()
+				if err == nil {
+					name = n
+				}
+			}
+			mn, err := node.LookupByString("message")
+			if err == nil {
+				m, err := mn.AsString()
+				if err == nil {
+					message = m
+				}
+			}
+			return fmt.Errorf("%s: %s", name, message)
+		},
+	)
 }
 
 var _ Publisher = (*PublisherService)(nil)
@@ -103,7 +196,12 @@ var _ Publisher = (*PublisherService)(nil)
 // configured claim path.
 //
 // Note: publicAddr address must be HTTP(S).
-func New(id crypto.PrivKey, publisherStore store.PublisherStore, publicAddr multiaddr.Multiaddr, opts ...Option) (*PublisherService, error) {
+func New(
+	id principal.Signer,
+	publisherStore store.PublisherStore,
+	publicAddr multiaddr.Multiaddr,
+	opts ...Option,
+) (*PublisherService, error) {
 	o := &options{}
 	for _, opt := range opts {
 		err := opt(o)
@@ -112,14 +210,19 @@ func New(id crypto.PrivKey, publisherStore store.PublisherStore, publicAddr mult
 		}
 	}
 
-	publisher, err := ipnipub.New(
-		id,
-		publisherStore,
-		ipnipub.WithDirectAnnounce("https://cid.contact/announce"),
-		ipnipub.WithAnnounceAddrs(publicAddr.String()),
-	)
+	priv, err := crypto.UnmarshalEd25519PrivateKey(id.Raw())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unmarshaling private key: %w", err)
+	}
+
+	ipnipubOpts := []ipnipub.Option{ipnipub.WithAnnounceAddrs(publicAddr.String())}
+	for _, u := range o.announceURLs {
+		log.Infof("Announcing new IPNI adverts to: %s", u.String())
+		ipnipubOpts = append(ipnipubOpts, ipnipub.WithDirectAnnounce(u.String()))
+	}
+	publisher, err := ipnipub.New(priv, publisherStore, ipnipubOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("creating IPNI publisher instance: %w", err)
 	}
 
 	found := false
@@ -132,24 +235,34 @@ func New(id crypto.PrivKey, publisherStore store.PublisherStore, publicAddr mult
 	if !found {
 		return nil, fmt.Errorf("IPNI publisher address is not HTTP(S): %s", publicAddr)
 	}
-	claimPath := o.claimPath
-	if claimPath == "" {
-		claimPath = fmt.Sprintf("claim/%s", claimPattern)
-	}
-	if !strings.Contains(claimPath, claimPattern) {
-		return nil, fmt.Errorf(`path string does not contain required pattern: "%s"`, claimPattern)
-	}
-	claimPath = strings.TrimPrefix(claimPath, "/")
 
-	peerid, err := peer.IDFromPrivateKey(id)
+	peerid, err := peer.IDFromPrivateKey(priv)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating libp2p peer ID from private key: %w", err)
 	}
-	peerInfo := peer.AddrInfo{
-		ID:    peerid,
-		Addrs: []multiaddr.Multiaddr{publicAddr},
+	provInfo := providerInfo(peerid, publicAddr)
+
+	if o.indexingService == nil {
+		log.Errorf("Indexing service is not configured - claims will not be cached")
 	}
-	return &PublisherService{publisherStore, publisher, peerInfo, claimPath}, nil
+
+	return &PublisherService{
+		id,
+		publisherStore,
+		publisher,
+		provInfo,
+		o.indexingService,
+		o.indexingServiceProofs,
+	}, nil
+}
+
+func providerInfo(peerID peer.ID, publicAddr multiaddr.Multiaddr) peer.AddrInfo {
+	provider := peer.AddrInfo{ID: peerID}
+	blobSuffix, _ := multiaddr.NewMultiaddr("/http-path/" + url.PathEscape("blob/{blob}"))
+	claimSuffix, _ := multiaddr.NewMultiaddr("/http-path/" + url.PathEscape("claim/{claim}"))
+	provider.Addrs = append(provider.Addrs, multiaddr.Join(publicAddr, blobSuffix))
+	provider.Addrs = append(provider.Addrs, multiaddr.Join(publicAddr, claimSuffix))
+	return provider
 }
 
 func asCID(link ipld.Link) cid.Cid {

--- a/pkg/service/publisher/publisher_test.go
+++ b/pkg/service/publisher/publisher_test.go
@@ -9,14 +9,20 @@ import (
 	"github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-datastore/sync"
 
-	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/multiformats/go-multihash"
 	"github.com/storacha/go-capabilities/pkg/assert"
+	"github.com/storacha/go-capabilities/pkg/claim"
 	"github.com/storacha/go-metadata"
+	"github.com/storacha/go-ucanto/client"
 	"github.com/storacha/go-ucanto/core/delegation"
-	"github.com/storacha/go-ucanto/principal/ed25519/signer"
+	"github.com/storacha/go-ucanto/core/invocation"
+	"github.com/storacha/go-ucanto/core/receipt"
+	"github.com/storacha/go-ucanto/principal"
+	"github.com/storacha/go-ucanto/server"
+	"github.com/storacha/go-ucanto/ucan"
 	"github.com/storacha/ipni-publisher/pkg/store"
+	"github.com/storacha/storage/pkg/capability"
 	"github.com/storacha/storage/pkg/internal/digestutil"
 	"github.com/storacha/storage/pkg/internal/testutil"
 	"github.com/storacha/storage/pkg/service/publisher/advertisement"
@@ -24,12 +30,6 @@ import (
 )
 
 func TestPublisherService(t *testing.T) {
-	signer, err := signer.Generate()
-	require.NoError(t, err)
-
-	priv, err := crypto.UnmarshalEd25519PrivateKey(signer.Raw())
-	require.NoError(t, err)
-
 	addr, err := multiaddr.NewMultiaddr("/dns4/localhost/tcp/3000/http")
 	require.NoError(t, err)
 
@@ -39,7 +39,7 @@ func TestPublisherService(t *testing.T) {
 		dstore := dssync.MutexWrap(datastore.NewMapDatastore())
 		publisherStore := store.FromDatastore(dstore)
 
-		svc, err := New(priv, publisherStore, addr)
+		svc, err := New(testutil.Alice, publisherStore, addr, WithLogLevel("info"))
 		require.NoError(t, err)
 
 		space := testutil.RandomDID()
@@ -47,9 +47,9 @@ func TestPublisherService(t *testing.T) {
 		location := testutil.Must(url.Parse(fmt.Sprintf("http://localhost:3000/blob/%s", digestutil.Format(shard))))(t)
 
 		claim, err := assert.Location.Delegate(
-			signer,
+			testutil.Alice,
 			space,
-			signer.DID().String(),
+			testutil.Alice.DID().String(),
 			assert.LocationCaveats{
 				Space:    space,
 				Content:  assert.FromHash(shard),
@@ -94,4 +94,75 @@ func TestPublisherService(t *testing.T) {
 		require.Len(t, ents, 1)
 		require.Equal(t, shard, ents[0])
 	})
+
+	t.Run("caches claims", func(t *testing.T) {
+		dstore := dssync.MutexWrap(datastore.NewMapDatastore())
+		publisherStore := store.FromDatastore(dstore)
+
+		idxSvc := mockIndexingService(t, testutil.Bob)
+		idxConn, err := client.NewConnection(testutil.Bob, idxSvc)
+		require.NoError(t, err)
+
+		// authorize alice to cache claim on bob
+		prf, err := delegation.Delegate(
+			testutil.Bob,
+			testutil.Alice,
+			[]ucan.Capability[ucan.NoCaveats]{
+				ucan.NewCapability(
+					claim.CacheAbility,
+					testutil.Bob.DID().String(),
+					ucan.NoCaveats{},
+				),
+			},
+		)
+		require.NoError(t, err)
+
+		svc, err := New(
+			testutil.Alice,
+			publisherStore,
+			addr,
+			WithIndexingService(idxConn),
+			WithIndexingServiceProof(delegation.FromDelegation(prf)),
+			WithLogLevel("info"),
+		)
+		require.NoError(t, err)
+
+		space := testutil.RandomDID()
+		shard := testutil.RandomMultihash()
+		location := testutil.Must(url.Parse(fmt.Sprintf("http://localhost:3000/blob/%s", digestutil.Format(shard))))(t)
+
+		claim, err := assert.Location.Delegate(
+			testutil.Alice,
+			space,
+			testutil.Alice.DID().String(),
+			assert.LocationCaveats{
+				Space:    space,
+				Content:  assert.FromHash(shard),
+				Location: []url.URL{*location},
+			},
+			delegation.WithNoExpiration(),
+		)
+		require.NoError(t, err)
+
+		err = svc.Publish(ctx, claim)
+		require.NoError(t, err)
+	})
+}
+
+func mockIndexingService(t *testing.T, id principal.Signer) server.ServerView {
+	t.Helper()
+	return testutil.Must(
+		server.NewServer(
+			id,
+			server.WithServiceMethod(
+				claim.CacheAbility,
+				server.Provide(
+					claim.Cache,
+					func(cap ucan.Capability[claim.CacheCaveats], inv invocation.Invocation, ctx server.InvocationContext) (capability.Unit, receipt.Effects, error) {
+						return capability.Unit{}, nil, nil
+					},
+				),
+			),
+		),
+	)(t)
 }

--- a/pkg/service/storage/service.go
+++ b/pkg/service/storage/service.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 
 	"github.com/ipfs/go-datastore"
-	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/storacha/go-ucanto/principal"
 	ed25519 "github.com/storacha/go-ucanto/principal/ed25519/signer"
 	"github.com/storacha/storage/pkg/service/blobs"
@@ -65,11 +64,6 @@ func New(opts ...Option) (*StorageService, error) {
 	}
 	log.Infof("Server ID: %s", id.DID())
 
-	priv, err := crypto.UnmarshalEd25519PrivateKey(id.Raw())
-	if err != nil {
-		return nil, fmt.Errorf("unmarshaling private key: %w", err)
-	}
-
 	var closeFuncs []func() error
 
 	blobStore := c.blobStore
@@ -115,7 +109,8 @@ func New(opts ...Option) (*StorageService, error) {
 		return nil, fmt.Errorf("creating blob service: %w", err)
 	}
 
-	claims, err := claims.New(priv, claimDs, publisherDs, pubURL)
+	claimsOpts := []claims.Option{claims.WithPublisherDirectAnnounce(c.announceURLs...)}
+	claims, err := claims.New(id, claimDs, publisherDs, pubURL, claimsOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating claim service: %w", err)
 	}

--- a/pkg/service/storage/ucan.go
+++ b/pkg/service/storage/ucan.go
@@ -138,7 +138,7 @@ func NewUCANServer(storageService Service) (server.ServerView, error) {
 
 					loc, err := storageService.Blobs().Access().GetDownloadURL(digest)
 					if err != nil {
-						log.Errorf("creating download URL for blob: %w", err)
+						log.Errorf("creating retrieval URL for blob: %w", err)
 						return blob.AcceptOk{}, nil, failure.FromError(err)
 					}
 


### PR DESCRIPTION
This PR allows configuration of the indexing service DID/URL and upgrades `publisher.Publish(...)` to make a `claim/cache` invocation to it.

TODO: actually send the claim in the invocation blocks (needs ucanto upgrade). See: https://github.com/storacha/go-ucanto/pull/27