### PR TITLE
feat: map blobstore implements filesystemer

### DIFF
--- a/pkg/service/blobs/server.go
+++ b/pkg/service/blobs/server.go
@@ -36,19 +36,7 @@ func NewBlobGetHandler(blobs blobstore.Blobstore) func(http.ResponseWriter, *htt
 	if fsblobs, ok := blobs.(blobstore.FileSystemer); ok {
 		serveHTTP := http.FileServer(fsblobs.FileSystem()).ServeHTTP
 		return func(w http.ResponseWriter, r *http.Request) {
-			_, bytes, err := multibase.Decode(r.PathValue("blob"))
-			if err != nil {
-				http.Error(w, fmt.Sprintf("decoding multibase encoded digest: %s", err), http.StatusBadRequest)
-				return
-			}
-
-			digest, err := multihash.Cast(bytes)
-			if err != nil {
-				http.Error(w, fmt.Sprintf("invalid multihash digest: %s", err), http.StatusBadRequest)
-				return
-			}
-
-			r.URL.Path = fsblobs.EncodePath(digest)
+			r.URL.Path = r.URL.Path[len("/blob"):]
 			serveHTTP(w, r)
 		}
 	}

--- a/pkg/service/blobs/server_test.go
+++ b/pkg/service/blobs/server_test.go
@@ -147,6 +147,7 @@ func requireRetrievableBlob(t *testing.T, endpoint url.URL, digest multihash.Mul
 	res, err := http.Get(bloburl.String())
 	require.NoError(t, err)
 
+	require.Equal(t, http.StatusOK, res.StatusCode)
 	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 	require.Equal(t, data, body)

--- a/pkg/store/blobstore/interface.go
+++ b/pkg/store/blobstore/interface.go
@@ -60,6 +60,4 @@ type Blobstore interface {
 type FileSystemer interface {
 	// FileSystem returns a filesystem interface for reading blobs.
 	FileSystem() http.FileSystem
-	// EncodePath converts a digest to a filesystem path.
-	EncodePath(digest multihash.Multihash) string
 }


### PR DESCRIPTION
This PR enables the map blobstore to present itself as a `http.FileSystem`. This is useful for testing with an ephemeral storage node.