### PR TITLE
fix(publisher): server paths

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -540,16 +540,6 @@ github.com/storacha/go-capabilities v0.0.0-20241021134022-7144600f5aeb h1:A9/44D
 github.com/storacha/go-capabilities v0.0.0-20241021134022-7144600f5aeb/go.mod h1:1x2qMcvOUvF6prSiWXsEeEfV3OcX/L2fk6iNgPMNfZU=
 github.com/storacha/go-metadata v0.0.0-20241021141939-f94d93dcda78 h1:NAti9hMLMo8F0Iyz5ldS41CY6MyukRH0OrTPV4u2340=
 github.com/storacha/go-metadata v0.0.0-20241021141939-f94d93dcda78/go.mod h1:DcwwQnyFuTk531cKD9sUkQg/gzpwKaIqH9I7oZYyeRc=
-github.com/storacha/go-ucanto v0.1.1-0.20241022122125-fc561a4d642c h1:Z8MZyBenGPhGE+w43UBhPq5uF2cri5o9zzyTmWM337Q=
-github.com/storacha/go-ucanto v0.1.1-0.20241022122125-fc561a4d642c/go.mod h1:vzifzvheQKs507Yr7qj2x4MYNrdBwjdKXtHsD3xpDm4=
-github.com/storacha/go-ucanto v0.1.1-0.20241027090114-eaad28302b8e h1:cBv5t6OePD16d/Zn2vUrNxvdI+r1nlAJE7P0/VjL3N0=
-github.com/storacha/go-ucanto v0.1.1-0.20241027090114-eaad28302b8e/go.mod h1:7ba9jAgqmwlF/JfyFUQcGV07uiYNlmJNu8qH4hHtrJk=
-github.com/storacha/go-ucanto v0.1.1-0.20241027115844-258d6f3c5ad1 h1:Pg9mpPTJFJasdyWIfXygRhds7OmikN8W7/OIb8egN+Y=
-github.com/storacha/go-ucanto v0.1.1-0.20241027115844-258d6f3c5ad1/go.mod h1:7ba9jAgqmwlF/JfyFUQcGV07uiYNlmJNu8qH4hHtrJk=
-github.com/storacha/go-ucanto v0.1.1-0.20241028093931-42d9e1db4bfb h1:bjubXTmLyLl7eap6HhIoFmwIH6H4CCtnJlcE4hbc2Qo=
-github.com/storacha/go-ucanto v0.1.1-0.20241028093931-42d9e1db4bfb/go.mod h1:7ba9jAgqmwlF/JfyFUQcGV07uiYNlmJNu8qH4hHtrJk=
-github.com/storacha/go-ucanto v0.1.1-0.20241028120259-a92a70795f51 h1:o8AMiYrFzDDoigYwRtmnUMGXkKJ3amZU2AJlErb830U=
-github.com/storacha/go-ucanto v0.1.1-0.20241028120259-a92a70795f51/go.mod h1:7ba9jAgqmwlF/JfyFUQcGV07uiYNlmJNu8qH4hHtrJk=
 github.com/storacha/go-ucanto v0.1.1-0.20241028122439-0d529756b469 h1:DBD9Ldp+Sa2/BMYWUo7o93kE5x1vGP9GKVyXUOFigSA=
 github.com/storacha/go-ucanto v0.1.1-0.20241028122439-0d529756b469/go.mod h1:7ba9jAgqmwlF/JfyFUQcGV07uiYNlmJNu8qH4hHtrJk=
 github.com/storacha/ipni-publisher v0.0.0-20241018055706-032286a2dc3f h1:62fTASO3wRPCWCkl6we2DftsFy/DfbmVpwJyqK7gmUc=

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -37,7 +37,7 @@ func ListenAndServe(addr string, service storage.Service) error {
 // NewServer creates a new storage node server.
 func NewServer(service storage.Service) (*http.ServeMux, error) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /", NewHandler(service.ID()))
+	mux.HandleFunc("GET /{$}", NewHandler(service.ID()))
 
 	httpUcanSrv, err := storage.NewServer(service)
 	if err != nil {
@@ -60,7 +60,7 @@ func NewServer(service storage.Service) (*http.ServeMux, error) {
 	publisherStore := service.Claims().Publisher().Store()
 	encodableStore, ok := publisherStore.(store.EncodeableStore)
 	if !ok {
-		return nil, errors.New("publisher store doe snot implement EncodableStore")
+		return nil, errors.New("publisher store does not implement EncodableStore")
 	}
 
 	httpPublisherSrv, err := publisher.NewServer(encodableStore)

--- a/pkg/service/publisher/server.go
+++ b/pkg/service/publisher/server.go
@@ -21,5 +21,5 @@ func NewServer(store store.EncodeableStore) (*Server, error) {
 }
 
 func (srv *Server) Serve(mux *http.ServeMux) {
-	mux.HandleFunc(fmt.Sprintf("GET %s", server.IPNIPath), srv.server.ServeHTTP)
+	mux.HandleFunc(fmt.Sprintf("GET %s/{ad}", server.IPNIPath), srv.server.ServeHTTP)
 }


### PR DESCRIPTION
This PR fixes the server paths - only return version info when direct hit on `/` and fix for IPNI advert path - includes a CID.