### PR TITLE
Add utilities for piece hashes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.23.2
 require (
 	github.com/aws/aws-sdk-go-v2 v1.32.2
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.65.3
+	github.com/filecoin-project/go-fil-commcid v0.2.0
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-ds-leveldb v0.5.0
@@ -17,6 +18,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.13.0
 	github.com/multiformats/go-multibase v0.2.0
 	github.com/multiformats/go-multihash v0.2.3
+	github.com/multiformats/go-varint v0.0.7
 	github.com/storacha/go-capabilities v0.0.0-20241021134022-7144600f5aeb
 	github.com/storacha/go-metadata v0.0.0-20241021141939-f94d93dcda78
 	github.com/storacha/go-ucanto v0.1.1-0.20241028163940-34de8cd912bb
@@ -78,7 +80,6 @@ require (
 	github.com/multiformats/go-multiaddr-fmt v0.1.0 // indirect
 	github.com/multiformats/go-multicodec v0.9.0 // indirect
 	github.com/multiformats/go-multistream v0.5.0 // indirect
-	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/onsi/gomega v1.34.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/filecoin-project/go-fil-commcid v0.2.0 h1:B+5UX8XGgdg/XsdUpST4pEBviKkFOw+Fvl2bLhSKGpI=
+github.com/filecoin-project/go-fil-commcid v0.2.0/go.mod h1:8yigf3JDIil+/WpqR5zoKyP0jBPCOGtEqq/K1CcMy9Q=
 github.com/flynn/noise v1.1.0 h1:KjPQoQCEFdZDiP03phOvGi11+SVVhBG2wOWAorLsstg=
 github.com/flynn/noise v1.1.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=

--- a/pkg/piece/digest/digest.go
+++ b/pkg/piece/digest/digest.go
@@ -1,0 +1,176 @@
+package digest
+
+import (
+	"fmt"
+
+	"github.com/multiformats/go-multihash"
+	"github.com/multiformats/go-varint"
+	"github.com/storacha/storage/pkg/piece/size"
+)
+
+const FR32_SHA256_TRUNC254_PADDED_BINARY_TREE_CODE = 0x1011
+const name = "fr32-sha2-256-trunc254-padded-binary-tree"
+
+func init() {
+	multihash.Codes[FR32_SHA256_TRUNC254_PADDED_BINARY_TREE_CODE] = name
+	multihash.Names[name] = FR32_SHA256_TRUNC254_PADDED_BINARY_TREE_CODE
+}
+
+var ErrWrongCode = fmt.Errorf("multihash code must be 0x%x", FR32_SHA256_TRUNC254_PADDED_BINARY_TREE_CODE)
+var ErrWrongName = fmt.Errorf("multihash name must be %s", name)
+
+type PieceDigest interface {
+	Bytes() []byte
+	Digest() []byte
+	Name() string
+	Code() uint64
+	Size() int
+	Padding() uint64
+	Height() uint8
+	DataCommitment() []byte
+}
+
+type pieceDigest []byte
+
+func (p pieceDigest) Bytes() []byte {
+	return p
+}
+
+// Code implements PieceDigest.
+func (p pieceDigest) Code() uint64 {
+	return FR32_SHA256_TRUNC254_PADDED_BINARY_TREE_CODE
+}
+
+// DataCommitment implements PieceDigest.
+func (p pieceDigest) DataCommitment() []byte {
+	dc, _ := DataCommitment(p)
+	return dc
+}
+
+// Digest implements PieceDigest.
+func (p pieceDigest) Digest() []byte {
+	d, _ := Digest(p)
+	return d
+}
+
+// Height implements PieceDigest.
+func (p pieceDigest) Height() uint8 {
+	h, _ := Height(p)
+	return h
+}
+
+// Name implements PieceDigest.
+func (p pieceDigest) Name() string {
+	return name
+}
+
+// Padding implements PieceDigest.
+func (p pieceDigest) Padding() uint64 {
+	pd, _ := Padding(p)
+	return pd
+}
+
+// Size implements PieceDigest.
+func (p pieceDigest) Size() int {
+	d, _ := Digest(p)
+	return len(d)
+}
+
+func NewPieceDigest(mh multihash.Multihash) (PieceDigest, error) {
+	// verify we pass all checks
+	_, err := Padding(mh)
+	if err != nil {
+		return nil, err
+	}
+	return pieceDigest(mh), nil
+}
+
+func Digest(mh []byte) ([]byte, error) {
+	decodedMh, err := multihash.Decode(mh)
+	if err != nil {
+		return nil, err
+	}
+	if decodedMh.Code != FR32_SHA256_TRUNC254_PADDED_BINARY_TREE_CODE {
+		return nil, ErrWrongCode
+	}
+	if decodedMh.Name != name {
+		return nil, ErrWrongCode
+	}
+	return decodedMh.Digest, nil
+}
+
+func Padding(pd []byte) (uint64, error) {
+	d, err := Digest(pd)
+	if err != nil {
+		return 0, err
+	}
+	padding, _, err := varint.FromUvarint(d)
+	return padding, err
+}
+
+func Height(pd []byte) (uint8, error) {
+	d, err := Digest(pd)
+	if err != nil {
+		return 0, err
+	}
+	_, read, err := varint.FromUvarint(d)
+	if err != nil {
+		return 0, fmt.Errorf("reading padding: %w", err)
+	}
+	return d[read], nil
+}
+
+func DataCommitment(pd []byte) ([]byte, error) {
+	d, err := Digest(pd)
+	if err != nil {
+		return nil, err
+	}
+	_, read, err := varint.FromUvarint(d)
+	if err != nil {
+		return nil, fmt.Errorf("reading padding: %w", err)
+	}
+	read++
+	return d[read:], nil
+}
+
+// ToDigest converts a raw data commitment and unpadded length to a v2 piece multihash
+// (i.e. log_2(padded data size in bytes) - 5, because 2^5 is 32 bytes which is the leaf node size) to a CID
+// by adding:
+// - hash type: multihash.SHA2_256_TRUNC254_PADDED_BINARY_TREE
+//
+// The helpers UnpaddedSizeToV1TreeHeight and Fr32PaddedSizeToV1TreeHeight may help in computing tree height
+func FromCommitmentAndSize(commD []byte, unpaddedDataSize uint64) (PieceDigest, error) {
+	if len(commD) != 32 {
+		return nil, fmt.Errorf("commitments must be 32 bytes long")
+	}
+
+	if unpaddedDataSize < 127 {
+		return nil, fmt.Errorf("unpadded data size must be at least 127, but was %d", unpaddedDataSize)
+	}
+
+	height, padding, err := size.UnpaddedSizeToV1TreeHeightAndPadding(unpaddedDataSize)
+	if err != nil {
+		return nil, err
+	}
+
+	if padding > varint.MaxValueUvarint63 {
+		return nil, fmt.Errorf("padded data size must be less than 2^63-1, but was %d", padding)
+	}
+
+	mh := FR32_SHA256_TRUNC254_PADDED_BINARY_TREE_CODE
+	paddingSize := varint.UvarintSize(padding)
+	digestSize := len(commD) + 1 + paddingSize
+
+	mhBuf := make(
+		[]byte,
+		varint.UvarintSize(uint64(mh))+varint.UvarintSize(uint64(digestSize))+digestSize,
+	)
+
+	pos := varint.PutUvarint(mhBuf, uint64(mh))
+	pos += varint.PutUvarint(mhBuf[pos:], uint64(digestSize))
+	pos += varint.PutUvarint(mhBuf[pos:], padding)
+	mhBuf[pos] = height
+	pos++
+	copy(mhBuf[pos:], commD)
+	return pieceDigest(mhBuf), nil
+}

--- a/pkg/piece/piece.go
+++ b/pkg/piece/piece.go
@@ -1,0 +1,103 @@
+package piece
+
+import (
+	"encoding/json"
+	"errors"
+
+	commcid "github.com/filecoin-project/go-fil-commcid"
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/datamodel"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/storacha/storage/pkg/piece/digest"
+	"github.com/storacha/storage/pkg/piece/size"
+)
+
+var ErrWrongLinkType = errors.New("must be a cid link")
+var ErrWrongCodec = errors.New("must be raw codec")
+
+type PieceLink interface {
+	PaddedSize() uint64
+	Padding() uint64
+	Height() uint8
+	DataCommitment() []byte
+	Link() ipld.Link
+	V1Link() ipld.Link
+	json.Marshaler
+}
+
+type pieceLink cidlink.Link
+
+// DataCommitment implements PieceLink.
+func (p pieceLink) DataCommitment() []byte {
+	dc, _ := digest.DataCommitment(p.Cid.Hash())
+	return dc
+}
+
+// Height implements PieceLink.
+func (p pieceLink) Height() uint8 {
+	h, _ := digest.Height(p.Cid.Hash())
+	return h
+}
+
+// Link implements PieceLink.
+func (p pieceLink) Link() datamodel.Link {
+	return cidlink.Link(p)
+}
+
+// PaddedSize implements PieceLink.
+func (p pieceLink) PaddedSize() uint64 {
+	return size.HeightToPaddedSize(p.Height())
+}
+
+// Padding implements PieceLink.
+func (p pieceLink) Padding() uint64 {
+	pd, _ := digest.Padding(p.Cid.Hash())
+	return pd
+}
+
+// V1Link implements PieceLink.
+func (p pieceLink) V1Link() datamodel.Link {
+	dc := p.DataCommitment()
+	v1, _ := commcid.DataCommitmentV1ToCID(dc)
+	return cidlink.Link{Cid: v1}
+}
+
+func FromPieceDigest(pd digest.PieceDigest) PieceLink {
+	return pieceLink(cidlink.Link{Cid: cid.NewCidV1(cid.Raw, pd.Bytes())})
+}
+
+func FromLink(link ipld.Link) (PieceLink, error) {
+	cl, ok := link.(cidlink.Link)
+	if !ok {
+		return nil, ErrWrongLinkType
+	}
+	if cl.Cid.Prefix().Codec != cid.Raw {
+		return nil, ErrWrongCodec
+	}
+
+	pieceDigest, err := digest.NewPieceDigest(cl.Cid.Hash())
+	if err != nil {
+		return nil, err
+	}
+	return FromPieceDigest(pieceDigest), nil
+}
+
+func FromV1LinkAndSize(link datamodel.Link, unpaddedDataSize uint64) (PieceLink, error) {
+	cl, ok := link.(cidlink.Link)
+	if !ok {
+		return nil, ErrWrongLinkType
+	}
+	if cl.Cid.Prefix().Codec != cid.Raw {
+		return nil, ErrWrongCodec
+	}
+	commitment, err := commcid.CIDToDataCommitmentV1(cl.Cid)
+	if err != nil {
+		return nil, err
+	}
+	pieceDigest, err := digest.FromCommitmentAndSize(commitment, unpaddedDataSize)
+	if err != nil {
+		return nil, err
+	}
+	return FromPieceDigest(pieceDigest), nil
+}

--- a/pkg/piece/size/size.go
+++ b/pkg/piece/size/size.go
@@ -1,0 +1,75 @@
+package size
+
+import (
+	"fmt"
+	"math/bits"
+)
+
+// Fr32PaddedSizeToV1TreeHeight calculates the height of the piece tree given data that's been FR32 padded. Because
+// pieces are only defined on binary trees if the size is not a power of 2 it will be rounded up to the next one under
+// the assumption that the rest of the tree will be padded out (e.g. with zeros)
+func Fr32PaddedSizeToV1TreeHeight(size uint64) uint8 {
+	if size <= 32 {
+		return 0
+	}
+
+	// Calculate the floor of log2(size)
+	b := 63 - bits.LeadingZeros64(size)
+	// Leaf size is 32 == 2^5
+	b -= 5
+
+	// Check if the size is a power of 2 and if not then add one since the tree will need to be padded out
+	if 32<<b < size {
+		b++
+	}
+	return uint8(b)
+}
+
+// UnpaddedSizeToV1TreeHeight calculates the height of the piece tree given the data that's meant to be encoded in the
+// tree before any FR32 padding is applied. Because pieces are only defined on binary trees of FR32 encoded data if the
+// size is not a power of 2 after the FR32 padding is applied it will be rounded up to the next one under the assumption
+// that the rest of the tree will be padded out (e.g. with zeros)
+func UnpaddedSizeToV1TreeHeight(size uint64) (uint8, error) {
+	if size*128 < size {
+		return 0, fmt.Errorf("unsupported size: too big")
+	}
+
+	paddedSize := size * 128 / 127
+	if paddedSize*127 != size*128 {
+		paddedSize++
+	}
+
+	return Fr32PaddedSizeToV1TreeHeight(paddedSize), nil
+}
+
+// UnpaddedSizeToV1TreeHeightAndPadding calculates the height of the piece tree given the data that's meant to be
+// encoded in the tree before any FR32 padding is applied. Because pieces are only defined on binary trees of FR32
+// encoded data if the size is not a power of 2 after the FR32 padding is applied it will be rounded up to the next one
+// under the assumption that the rest of the tree will be padded out (e.g. with zeros). The amount of data padding that
+// is needed to be applied is returned alongside the tree height.
+func UnpaddedSizeToV1TreeHeightAndPadding(dataSize uint64) (uint8, uint64, error) {
+	if dataSize*128 < dataSize {
+		return 0, 0, fmt.Errorf("unsupported size: too big")
+	}
+
+	if dataSize < 127 {
+		return 0, 0, fmt.Errorf("unsupported size: too small")
+	}
+
+	fr32DataSize := dataSize * 128 / 127
+	// If the FR32 padding doesn't fill an exact number of bytes add up to 1 more byte of zeros to round it out
+	if fr32DataSize*127 != dataSize*128 {
+		fr32DataSize++
+	}
+
+	treeHeight := Fr32PaddedSizeToV1TreeHeight(fr32DataSize)
+	paddedFr32DataSize := HeightToPaddedSize(treeHeight)
+	paddedDataSize := paddedFr32DataSize / 128 * 127
+	padding := paddedDataSize - dataSize
+
+	return treeHeight, padding, nil
+}
+
+func HeightToPaddedSize(height uint8) uint64 {
+	return uint64(32) << height
+}


### PR DESCRIPTION
# Goals

So great news, [state of piececid v2 in goland is a mess](https://github.com/filecoin-project/go-fil-commcid/pull/5#issuecomment-2442664584), so I ported everything from [JS data-segment](https://github.com/storacha/data-segment) to go

# Implementation

There are mild variations and I took the code in @aschmahmann 's unmerged PR but basically this gives us a PieceDigest and PieceLink analogous to the types in JS data-segment.

# For Discussion

Needs tests
