### PR TITLE
feat: support PEM key generation. `stroage state` expects private-key via file

### DIFF
--- a/cmd/enum/keyfmt.go
+++ b/cmd/enum/keyfmt.go
@@ -1,4 +1,4 @@
-package types
+package enum
 
 // inspiration: https://github.com/zarldev/goenums
 

--- a/cmd/identity.go
+++ b/cmd/identity.go
@@ -1,12 +1,22 @@
 package cmd
 
 import (
+	"bytes"
+	crypto_ed25519 "crypto/ed25519"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
+	"os"
+	"strings"
 
+	"github.com/storacha/go-ucanto/principal"
 	ed25519 "github.com/storacha/go-ucanto/principal/ed25519/signer"
+	"github.com/storacha/storage/cmd/types"
 	"github.com/urfave/cli/v2"
 )
+
+var keyFormat string
 
 var IdentityCmd = &cli.Command{
 	Name:    "identity",
@@ -18,36 +28,102 @@ var IdentityCmd = &cli.Command{
 			Aliases: []string{"gen"},
 			Usage:   "Generate a new decentralized identity.",
 			Flags: []cli.Flag{
-				&cli.BoolFlag{
-					Name:  "json",
-					Usage: "output JSON",
+				&cli.StringFlag{
+					Name:        "type",
+					Aliases:     []string{"t"},
+					Usage:       fmt.Sprintf("Output format type. Accepted values: %s", types.KeyFormats.All()),
+					Value:       "JSON",
+					Destination: &keyFormat,
 				},
 			},
 			Action: func(cCtx *cli.Context) error {
+				format := types.ParseKeyFormat(strings.ToUpper(keyFormat))
+				if !format.IsValid() {
+					return fmt.Errorf("unknown type: '%s'. Accepted values: %s", keyFormat, types.KeyFormats.All())
+				}
+
 				signer, err := ed25519.Generate()
 				if err != nil {
 					return fmt.Errorf("generating ed25519 key: %w", err)
 				}
-				did := signer.DID().String()
-				key, err := ed25519.Format(signer)
-				if err != nil {
-					return fmt.Errorf("formatting ed25519 key: %w", err)
-				}
-				if cCtx.Bool("json") {
-					out, err := json.Marshal(struct {
-						DID string `json:"did"`
-						Key string `json:"key"`
-					}{did, key})
+
+				var out []byte
+				switch format {
+				case types.KeyFormats.JSON:
+					out, err = marshalJSONKey(signer)
 					if err != nil {
 						return fmt.Errorf("marshaling JSON: %w", err)
 					}
-					fmt.Println(string(out))
-				} else {
-					fmt.Printf("# %s\n", did)
-					fmt.Println(key)
+				case types.KeyFormats.PEM:
+					out, err = marshalPEMKey(signer)
+					if err != nil {
+						return fmt.Errorf("marshaling PEM: %w", err)
+					}
+				default:
+					return fmt.Errorf("unknown format: %s", keyFormat)
 				}
+
+				// print the did to stderr allowing the output of the command to be redirected to a file.
+				if _, err := fmt.Fprintf(os.Stderr, "# %s\n", signer.DID()); err != nil {
+					return fmt.Errorf("writing output: %w", err)
+				}
+				if n, err := fmt.Fprintf(os.Stdout, string(out)); err != nil {
+					return fmt.Errorf("writing output: %w", err)
+				} else if n != len(out) {
+					return fmt.Errorf("writing output: wrote %d of %d bytes", n, len(out))
+				}
+
 				return nil
 			},
 		},
 	},
+}
+
+func marshalPEMKey(signer principal.Signer) ([]byte, error) {
+	privateKey := crypto_ed25519.PrivateKey(signer.Raw())
+	// Marshal and encode the private key
+	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling ed25519 private key: %w", err)
+	}
+	privateKeyBlock := &pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: privateKeyBytes,
+	}
+
+	buffer := new(bytes.Buffer)
+	if err := pem.Encode(buffer, privateKeyBlock); err != nil {
+		return nil, fmt.Errorf("encoding ed25519 private key: %w", err)
+	}
+
+	// Marshal and encode the public key
+	publicKeyBytes, err := x509.MarshalPKIXPublicKey(privateKey.Public())
+	if err != nil {
+		return nil, fmt.Errorf("marshaling ed25519 public key: %w", err)
+	}
+	publicKeyBlock := &pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: publicKeyBytes,
+	}
+	// Append the public key block to the same file
+	if err := pem.Encode(buffer, publicKeyBlock); err != nil {
+		return nil, fmt.Errorf("encoding ed25519 public key: %w", err)
+	}
+	return buffer.Bytes(), nil
+}
+
+func marshalJSONKey(signer principal.Signer) ([]byte, error) {
+	did := signer.DID().String()
+	key, err := ed25519.Format(signer)
+	if err != nil {
+		return nil, fmt.Errorf("formatting ed25519 key: %w", err)
+	}
+	out, err := json.Marshal(struct {
+		DID string `json:"did"`
+		Key string `json:"key"`
+	}{did, key})
+	if err != nil {
+		return nil, fmt.Errorf("marshaling JSON: %w", err)
+	}
+	return out, nil
 }

--- a/cmd/identity_test.go
+++ b/cmd/identity_test.go
@@ -1,0 +1,57 @@
+package cmd_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/storacha/storage/cmd"
+	"github.com/storacha/storage/cmd/enum"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateSignerKeyPairAndPrincipalSignerFromFile(t *testing.T) {
+	tests := []struct {
+		name   string
+		format enum.KeyFormat
+		ext    string
+	}{
+		{
+			name:   "JSON round-trip",
+			format: enum.KeyFormats.JSON,
+			ext:    "json",
+		},
+		{
+			name:   "PEM round-trip",
+			format: enum.KeyFormats.PEM,
+			ext:    "pem",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// create the signer/key bytes in the specified format
+			origSigner, keyBytes, err := cmd.CreateSignerKeyPair(tt.format)
+			require.NoError(t, err, "CreateSignerKeyPair should succeed")
+
+			// write the key bytes to a temporary file
+			tmpDir := t.TempDir()
+			filePath := filepath.Join(tmpDir, "test."+tt.ext)
+			err = os.WriteFile(filePath, keyBytes, 0600)
+			require.NoError(t, err, "should be able to write key file")
+
+			// read them back into a new signer
+			loadedSigner, err := cmd.PrincipalSignerFromFile(filePath)
+			require.NoError(t, err, "PrincipalSignerFromFile should succeed")
+
+			// confirm private keys match
+			require.True(t, bytes.Equal(origSigner.Raw(), loadedSigner.Raw()),
+				"loaded signer's private key should match the original")
+
+			// confirm that the DIDs match as well
+			require.Equal(t, origSigner.DID().String(), loadedSigner.DID().String(),
+				"DID of loaded signer should match the original")
+		})
+	}
+}

--- a/cmd/types/keyfmt.go
+++ b/cmd/types/keyfmt.go
@@ -1,0 +1,91 @@
+package types
+
+// inspiration: https://github.com/zarldev/goenums
+
+import "fmt"
+
+type KeyFormat struct {
+	keyFormat
+}
+
+type keyFormat int
+
+const (
+	unknown keyFormat = iota
+	json
+	pem
+)
+
+var (
+	strOperationMap = map[keyFormat]string{
+		json: "JSON",
+		pem:  "PEM",
+	}
+
+	typeOperationMap = map[string]keyFormat{
+		"JSON": json,
+		"PEM":  pem,
+	}
+)
+
+func (t keyFormat) String() string {
+	return strOperationMap[t]
+}
+
+func ParseKeyFormat(a any) KeyFormat {
+	switch v := a.(type) {
+	case KeyFormat:
+		return v
+	case string:
+		return KeyFormat{stringToOperation(v)}
+	case fmt.Stringer:
+		return KeyFormat{stringToOperation(v.String())}
+	case int:
+		return KeyFormat{keyFormat(v)}
+	case int64:
+		return KeyFormat{keyFormat(int(v))}
+	case int32:
+		return KeyFormat{keyFormat(int(v))}
+	}
+	return KeyFormat{unknown}
+}
+
+func stringToOperation(s string) keyFormat {
+	if v, ok := typeOperationMap[s]; ok {
+		return v
+	}
+	return unknown
+}
+
+func (t keyFormat) IsValid() bool {
+	_, ok := strOperationMap[t]
+	return ok
+}
+
+type keyFormatContainer struct {
+	UNKNOWN KeyFormat
+	JSON    KeyFormat
+	PEM     KeyFormat
+}
+
+var KeyFormats = keyFormatContainer{
+	UNKNOWN: KeyFormat{unknown},
+	JSON:    KeyFormat{json},
+	PEM:     KeyFormat{pem},
+}
+
+func (c keyFormatContainer) All() []KeyFormat {
+	return []KeyFormat{
+		c.JSON,
+		c.PEM,
+	}
+}
+
+func (t KeyFormat) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + t.String() + `"`), nil
+}
+
+func (t *KeyFormat) UnmarshalJSON(b []byte) error {
+	*t = ParseKeyFormat(string(b))
+	return nil
+}


### PR DESCRIPTION
## Motivation
Curio strictly requires authentication keys in PEM format for requests from Storacha storage nodes ([details here](https://github.com/storacha/storage/blob/0ff93a070c66136365f920b62b9500ba775789d8/deploy/pdp/README.md#2-create-a-pem-file-the-storacha-storage-node) (draw the rest of the bespoken owl)). Previously, the `storage id gen` command only generated keys in JSON format, which is incompatible with Curio’s PEM requirement. Additionally, the JSON output from `storage id gen` was cumbersome and not easily integrated with the storage start command, which expects a private key file to initialize the node and sign JWT tokens.

## Benefits of this Change
- Enables direct generation of keys in PEM format, meeting Curio’s authentication requirements.
- Streamlines usage by ensuring compatibility between keys generated by `storage id gen` and those consumed by `storage start`.

## How it Works After this Change
- `storage id gen` now supports outputting keys in both PEM and JSON formats.
- The `storage start` command has been updated to accept either a PEM or JSON key file, utilizing the provided private key to sign JWT tokens for authenticating with Curio.
- Tests have been added to validate the round-trip functionality for both PEM and JSON formats.

## Example Usage
Here's an example demonstrating how the improved commands can be used together:
```bash
$ storage id gen -t pem > key.pem
# did:key:z6MkkShiNqAnmQ7dmhk1cBUAceYMofHiRuAU1V5HYSUFJM5M

$ storage start --key-file=key.pem
🔥 Storage Node v0.0.0
🆔 did:key:z6MkkShiNqAnmQ7dmhk1cBUAceYMofHiRuAU1V5HYSUFJM5M
🚀 Ready!

$ storage id gen -t=json > key.json
# did:key:z6MkgF8pibdpeBJCumUKfXg9LtpVsaCPococ3W8vh1BAGAZ1RZ

$ storage start --key-file=key.json
🔥 Storage Node v0.0.0
🆔 did:key:z6MkgF8pibdpeBJCumUKfXg9LtpVsaCPoc3W8vh1BAGAZ1RZ
🚀 Ready!
```

### PEM File Content Description: 
The PEM file contains two sections encoded in PEM format:

1. Private Key (PKCS#8 encoded):
Contains the Ed25519 private key used by the Storacha storage node for its signing things, like JWT tokens, ucan, etc.

2. Public Key (PKIX format)
The corresponding public key used to derive the node's identifier (DID).

The PEM file structure will look like:
```
-----BEGIN PRIVATE KEY-----
<base64-encoded private key>
-----END PRIVATE KEY-----
-----BEGIN PUBLIC KEY-----
<base64-encoded public key>
-----END PUBLIC KEY-----
```
This file allows the storage node to authenticate with Curio by signing JWT tokens and providing the necessary public information to derive the node's DID.