### PR TITLE
refactor: migrate remaining cli commands to use key-file

### DIFF
--- a/cmd/delegation.go
+++ b/cmd/delegation.go
@@ -9,7 +9,6 @@ import (
 	"github.com/storacha/go-libstoracha/capabilities/pdp"
 	"github.com/storacha/go-ucanto/core/delegation"
 	"github.com/storacha/go-ucanto/did"
-	ed25519 "github.com/storacha/go-ucanto/principal/ed25519/signer"
 	"github.com/storacha/go-ucanto/ucan"
 	"github.com/urfave/cli/v2"
 )
@@ -24,7 +23,7 @@ var DelegationCmd = &cli.Command{
 			Aliases: []string{"gen"},
 			Usage:   "Generate a new storage delegation",
 			Flags: []cli.Flag{
-				PrivateKeyFlag,
+				KeyFileFlag,
 				&cli.StringFlag{
 					Name:     "client-did",
 					Aliases:  []string{"d"},
@@ -34,7 +33,7 @@ var DelegationCmd = &cli.Command{
 				},
 			},
 			Action: func(cCtx *cli.Context) error {
-				id, err := ed25519.Parse(cCtx.String("private-key"))
+				id, err := PrincipalSignerFromFile(cCtx.String("key-file"))
 				if err != nil {
 					return fmt.Errorf("parsing private key: %w", err)
 				}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -1,17 +1,19 @@
 package cmd
 
-import "github.com/urfave/cli/v2"
+import (
+	"github.com/urfave/cli/v2"
+)
 
 func RequiredStringFlag(strFlag *cli.StringFlag) *cli.StringFlag {
-	copy := *strFlag
-	copy.Required = true
-	return &copy
+	cpy := *strFlag
+	cpy.Required = true
+	return &cpy
 }
 
 func RequiredIntFlag(strFlag *cli.Int64Flag) *cli.Int64Flag {
-	copy := *strFlag
-	copy.Required = true
-	return &copy
+	cpy := *strFlag
+	cpy.Required = true
+	return &cpy
 }
 
 var CurioURLFlag = &cli.StringFlag{
@@ -21,12 +23,12 @@ var CurioURLFlag = &cli.StringFlag{
 	EnvVars: []string{"STORAGE_CURIO_URL"},
 }
 
-var PrivateKeyFlag = &cli.StringFlag{
-	Name:     "private-key",
-	Aliases:  []string{"s"},
-	Usage:    "Multibase base64 encoded private key identity for the node.",
-	EnvVars:  []string{"STORAGE_PRIVATE_KEY"},
-	Required: true,
+var KeyFileFlag = &cli.PathFlag{
+	Name:      "key-file",
+	Usage:     "Path to a file containing ed25519 private key, typically created by the id gen command.",
+	EnvVars:   []string{"STORAGE_PRIVATE_KEY"},
+	Required:  true,
+	TakesFile: true,
 }
 
 var ClientKeyFlag = &cli.StringFlag{

--- a/cmd/proofset.go
+++ b/cmd/proofset.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/url"
 
-	ed25519 "github.com/storacha/go-ucanto/principal/ed25519/signer"
 	"github.com/storacha/storage/pkg/pdp/curio"
 	"github.com/urfave/cli/v2"
 )
@@ -21,8 +20,8 @@ var ProofSetCmd = &cli.Command{
 			Aliases: []string{"c"},
 			Usage:   "Generate a new proofset",
 			Flags: []cli.Flag{
+				KeyFileFlag,
 				RequiredStringFlag(CurioURLFlag),
-				PrivateKeyFlag,
 				&cli.StringFlag{
 					Name:     "record-keeper",
 					Aliases:  []string{"rk"},
@@ -32,15 +31,16 @@ var ProofSetCmd = &cli.Command{
 				},
 			},
 			Action: func(cCtx *cli.Context) error {
-				curioURLStr := cCtx.String("curio-url")
-				curioURL, err := url.Parse(curioURLStr)
-				if err != nil {
-					return fmt.Errorf("parsing curio URL: %w", err)
-				}
-				id, err := ed25519.Parse(cCtx.String("private-key"))
+				id, err := PrincipalSignerFromFile(cCtx.String("key-file"))
 				if err != nil {
 					return fmt.Errorf("parsing private key: %w", err)
 				}
+
+				curioURL, err := url.Parse(cCtx.String("curio-url"))
+				if err != nil {
+					return fmt.Errorf("parsing curio URL: %w", err)
+				}
+
 				curioAuth, err := curio.CreateCurioJWTAuthHeader("storacha", id)
 				if err != nil {
 					return fmt.Errorf("generating curio jwt: %w", err)
@@ -62,7 +62,7 @@ var ProofSetCmd = &cli.Command{
 			Aliases: []string{"cs"},
 			Usage:   "check on progress creating a proofset",
 			Flags: []cli.Flag{
-				PrivateKeyFlag,
+				KeyFileFlag,
 				RequiredStringFlag(CurioURLFlag),
 				&cli.StringFlag{
 					Name:     "ref-url",
@@ -73,15 +73,16 @@ var ProofSetCmd = &cli.Command{
 				},
 			},
 			Action: func(cCtx *cli.Context) error {
-				curioURLStr := cCtx.String("curio-url")
-				curioURL, err := url.Parse(curioURLStr)
+				curioURL, err := url.Parse(cCtx.String("curio-url"))
 				if err != nil {
 					return fmt.Errorf("parsing curio URL: %w", err)
 				}
-				id, err := ed25519.Parse(cCtx.String("private-key"))
+
+				id, err := PrincipalSignerFromFile(cCtx.String("key-file"))
 				if err != nil {
 					return fmt.Errorf("parsing private key: %w", err)
 				}
+
 				curioAuth, err := curio.CreateCurioJWTAuthHeader("storacha", id)
 				if err != nil {
 					return fmt.Errorf("generating curio jwt: %w", err)
@@ -107,20 +108,21 @@ var ProofSetCmd = &cli.Command{
 			Aliases: []string{"g"},
 			Usage:   "get a proofs set",
 			Flags: []cli.Flag{
-				PrivateKeyFlag,
+				KeyFileFlag,
 				RequiredStringFlag(CurioURLFlag),
 				RequiredIntFlag(ProofSetFlag),
 			},
 			Action: func(cCtx *cli.Context) error {
-				curioURLStr := cCtx.String("curio-url")
-				curioURL, err := url.Parse(curioURLStr)
+				curioURL, err := url.Parse(cCtx.String("curio-url"))
 				if err != nil {
 					return fmt.Errorf("parsing curio URL: %w", err)
 				}
-				id, err := ed25519.Parse(cCtx.String("private-key"))
+
+				id, err := PrincipalSignerFromFile(cCtx.String("key-file"))
 				if err != nil {
 					return fmt.Errorf("parsing private key: %w", err)
 				}
+
 				curioAuth, err := curio.CreateCurioJWTAuthHeader("storacha", id)
 				if err != nil {
 					return fmt.Errorf("generating curio jwt: %w", err)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -30,19 +30,12 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var privKeyFile string
-
 var StartCmd = &cli.Command{
 	Name:  "start",
 	Usage: "Start the storage node daemon.",
 	Flags: []cli.Flag{
+		KeyFileFlag,
 		CurioURLFlag,
-		&cli.PathFlag{
-			Name:        "key-file",
-			Usage:       "Path to a file containing ed25519 private key, typically created by the id gen command.",
-			Required:    true,
-			Destination: &privKeyFile,
-		},
 		&cli.IntFlag{
 			Name:    "port",
 			Aliases: []string{"p"},
@@ -76,7 +69,7 @@ var StartCmd = &cli.Command{
 		},
 	},
 	Action: func(cCtx *cli.Context) error {
-		id, err := PrincipalSignerFromFile(privKeyFile)
+		id, err := PrincipalSignerFromFile(cCtx.String("key-file"))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
a follow on to https://github.com/storacha/storage/pull/46 that moves rest of commands to --key-file pattern.