### PR TITLE
refactor: separate blob allocation and acceptance logic into dedicated files

### DIFF
--- a/pkg/service/storage/blob_accept.go
+++ b/pkg/service/storage/blob_accept.go
@@ -1,0 +1,105 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/storacha/go-libstoracha/capabilities/assert"
+	"github.com/storacha/go-libstoracha/capabilities/blob"
+	"github.com/storacha/go-libstoracha/capabilities/types"
+	"github.com/storacha/go-libstoracha/piece/piece"
+	"github.com/storacha/go-ucanto/core/delegation"
+	"github.com/storacha/go-ucanto/did"
+
+	"github.com/storacha/storage/pkg/internal/digestutil"
+	"github.com/storacha/storage/pkg/store"
+)
+
+type BlobAcceptRequest struct {
+	Space did.DID
+	Blob  blob.Blob
+	Put   blob.Promise
+}
+
+type BlobAcceptResponse struct {
+	Claim delegation.Delegation
+	// only present when using PDP
+	Piece *piece.PieceLink
+}
+
+func blobAccept(ctx context.Context, service Service, req *BlobAcceptRequest) (*BlobAcceptResponse, error) {
+	log := log.With("blob", digestutil.Format(req.Blob.Digest))
+	log.Infof("%s %s", blob.AcceptAbility, req.Space)
+
+	var (
+		err      error
+		loc      url.URL
+		pdpPiece piece.PieceLink
+		resp     = new(BlobAcceptResponse)
+	)
+	if service.PDP() == nil {
+		_, err = service.Blobs().Store().Get(ctx, req.Blob.Digest)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				return nil, NewAllocatedMemoryNotWrittenError()
+			}
+			log.Errorw("getting blob", "error", err)
+			return nil, fmt.Errorf("getting blob: %w", err)
+		}
+
+		loc, err = service.Blobs().Access().GetDownloadURL(req.Blob.Digest)
+		if err != nil {
+			log.Errorw("creating retrieval URL for blob", "error", err)
+			return nil, fmt.Errorf("creating retrieval URL for blob: %w", err)
+		}
+	} else {
+		// locate the piece from the pdp service
+		pdpPiece, err = service.PDP().PieceFinder().FindPiece(ctx, req.Blob.Digest, req.Blob.Size)
+		if err != nil {
+			log.Errorw("finding piece for blob", "error", err)
+			return nil, fmt.Errorf("finding piece for blob: %w", err)
+		}
+		// get a download url
+		loc = service.PDP().PieceFinder().URLForPiece(pdpPiece)
+		// submit the piece for aggregation
+		err = service.PDP().Aggregator().AggregatePiece(ctx, pdpPiece)
+		if err != nil {
+			log.Errorw("submitting piece for aggregation", "error", err)
+			return nil, fmt.Errorf("submitting piece for aggregation: %w", err)
+		}
+		resp.Piece = &pdpPiece
+	}
+
+	claim, err := assert.Location.Delegate(
+		service.ID(),
+		req.Space,
+		service.ID().DID().String(),
+		assert.LocationCaveats{
+			Space:    req.Space,
+			Content:  types.FromHash(req.Blob.Digest),
+			Location: []url.URL{loc},
+		},
+		delegation.WithNoExpiration(),
+	)
+	if err != nil {
+		log.Errorw("creating location commitment", "error", err)
+		return nil, fmt.Errorf("creating location commitment: %w", err)
+	}
+
+	err = service.Claims().Store().Put(ctx, claim)
+	if err != nil {
+		log.Errorw("putting location claim for blob", "error", err)
+		return nil, fmt.Errorf("putting location claim for blob: %w", err)
+	}
+
+	err = service.Claims().Publisher().Publish(ctx, claim)
+	if err != nil {
+		log.Errorw("publishing location commitment", "error", err)
+		return nil, fmt.Errorf("publishing location commitment: %w", err)
+	}
+
+	resp.Claim = claim
+	return resp, nil
+}

--- a/pkg/service/storage/blob_allocate.go
+++ b/pkg/service/storage/blob_allocate.go
@@ -1,0 +1,152 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/storacha/go-libstoracha/capabilities/blob"
+	"github.com/storacha/go-ucanto/did"
+	"github.com/storacha/go-ucanto/ucan"
+
+	"github.com/storacha/storage/pkg/internal/digestutil"
+	"github.com/storacha/storage/pkg/store"
+	"github.com/storacha/storage/pkg/store/allocationstore/allocation"
+)
+
+type BlobAllocateRequest struct {
+	Space           did.DID
+	Blob            blob.Blob
+	AllocationCause ucan.Link
+	InvocationCause ucan.Link
+}
+
+type BlobAllocateResponse struct {
+	Size    uint64
+	Address *blob.Address
+}
+
+func blobAllocate(
+	ctx context.Context,
+	service Service,
+	req *BlobAllocateRequest,
+) (*BlobAllocateResponse, error) {
+	log := log.With("blob", digestutil.Format(req.Blob.Digest))
+	log.Infof("%s space: %s", blob.AllocateAbility, req.Space)
+
+	// check if we already have an allocation for the blob in this space
+	allocs, err := service.Blobs().Allocations().List(ctx, req.Blob.Digest)
+	if err != nil {
+		log.Errorw("getting allocations", "error", err)
+		return nil, fmt.Errorf("getting allocations: %w", err)
+	}
+
+	allocated := false
+	for _, a := range allocs {
+		if a.Space == req.Space {
+			allocated = true
+			break
+		}
+	}
+
+	received := false
+	// check if we received the blob (only possible if we have an allocation)
+	if len(allocs) > 0 {
+		if service.PDP() != nil {
+			_, err = service.PDP().PieceFinder().FindPiece(ctx, req.Blob.Digest, req.Blob.Size)
+		} else {
+			_, err = service.Blobs().Store().Get(ctx, req.Blob.Digest)
+		}
+		if err == nil {
+			received = true
+		}
+		if err != nil && !errors.Is(err, store.ErrNotFound) {
+			log.Errorw("getting blob", "error", err)
+			return nil, fmt.Errorf("getting blob: %w", err)
+		}
+	}
+
+	// the size reported in the receipt is the number of bytes allocated
+	// in the space - if a previous allocation already exists, this has
+	// already been done, so the allocation size is 0
+	size := req.Blob.Size
+	if allocated {
+		log.Info("blob allocation already exists")
+		size = 0
+	}
+
+	// nothing to do
+	if allocated && received {
+		log.Info("blob already received")
+		return &BlobAllocateResponse{
+			Size: size,
+			// NB: blob already receieved, therefor no address is needed for upload.
+			Address: nil,
+		}, nil
+	}
+
+	expiresIn := uint64(60 * 60 * 24) // 1 day
+	expiresAt := uint64(time.Now().Unix()) + expiresIn
+
+	var address *blob.Address
+	// if not received yet, we need to generate a signed URL for the
+	// upload, and include it in the receipt.
+	if !received {
+		var uploadURL url.URL
+		headers := http.Header{}
+		if service.PDP() == nil {
+			// use standard blob upload
+			uploadURL, headers, err = service.Blobs().Presigner().SignUploadURL(ctx, req.Blob.Digest, req.Blob.Size, expiresIn)
+			if err != nil {
+				log.Errorw("signing upload URL", "error", err)
+				return nil, fmt.Errorf("signing upload URL: %w", err)
+			}
+		} else {
+			// use pdp service upload
+			urlP, err := service.PDP().PieceAdder().AddPiece(ctx, req.Blob.Digest, req.Blob.Size)
+			if err != nil {
+				log.Errorw("adding to pdp service", "error", err)
+				return nil, fmt.Errorf("adding to pdp service: %w", err)
+			}
+			uploadURL = *urlP
+		}
+		address = &blob.Address{
+			URL:     uploadURL,
+			Headers: headers,
+			Expires: expiresAt,
+		}
+	}
+
+	// even if a previous allocation was made in this space, we create
+	// another for the new invocation.
+	err = service.Blobs().Allocations().Put(ctx, allocation.Allocation{
+		Space:   req.Space,
+		Blob:    allocation.Blob(req.Blob),
+		Expires: expiresAt,
+		// REVIEW: is this the correct cause? The invocation link rather than the allocate caveats cause field?
+		Cause: req.InvocationCause,
+	})
+	if err != nil {
+		log.Errorw("putting allocation", "error", err)
+		return nil, fmt.Errorf("putting allocation: %w", err)
+	}
+
+	a, err := service.Blobs().Allocations().List(ctx, req.Blob.Digest)
+	if err != nil {
+		log.Errorw("listing allocation after put", "error", err)
+		return nil, fmt.Errorf("listing allocation after put: %w", err)
+	}
+	if len(a) < 1 {
+		log.Error("failed to read allocation after write")
+		return nil, fmt.Errorf("failed to read allocation after write")
+	}
+	log.Info("successfully read allocation after write")
+
+	return &BlobAllocateResponse{
+		Size:    size,
+		Address: address,
+	}, nil
+}

--- a/pkg/service/storage/ucan.go
+++ b/pkg/service/storage/ucan.go
@@ -2,13 +2,8 @@ package storage
 
 import (
 	"context"
-	"errors"
-	"net/http"
-	"net/url"
-	"time"
 
 	logging "github.com/ipfs/go-log/v2"
-	"github.com/storacha/go-libstoracha/capabilities/assert"
 	"github.com/storacha/go-libstoracha/capabilities/blob"
 	"github.com/storacha/go-libstoracha/capabilities/pdp"
 	"github.com/storacha/go-libstoracha/capabilities/types"
@@ -21,9 +16,6 @@ import (
 	fdm "github.com/storacha/go-ucanto/core/result/failure/datamodel"
 	"github.com/storacha/go-ucanto/server"
 	"github.com/storacha/go-ucanto/ucan"
-	"github.com/storacha/storage/pkg/internal/digestutil"
-	"github.com/storacha/storage/pkg/store"
-	"github.com/storacha/storage/pkg/store/allocationstore/allocation"
 )
 
 var log = logging.Logger("storage")
@@ -38,119 +30,40 @@ func NewUCANServer(storageService Service, options ...server.Option) (server.Ser
 			server.Provide(
 				blob.Allocate,
 				func(cap ucan.Capability[blob.AllocateCaveats], inv invocation.Invocation, iCtx server.InvocationContext) (blob.AllocateOk, fx.Effects, error) {
-					ctx := context.TODO()
-					digest := cap.Nb().Blob.Digest
-					log := log.With("blob", digestutil.Format(digest))
-					log.Infof("%s space: %s", blob.AllocateAbility, cap.Nb().Space)
+					//
+					// UCAN Validation
+					//
 
 					// only service principal can perform an allocation
 					if cap.With() != iCtx.ID().DID().String() {
 						return blob.AllocateOk{}, nil, NewUnsupportedCapabilityError(cap)
 					}
-					// check if we already have an allocation for the blob in this space
-					allocs, err := storageService.Blobs().Allocations().List(ctx, digest)
-					if err != nil {
-						log.Errorf("getting allocations: %w", err)
-						return blob.AllocateOk{}, nil, failure.FromError(err)
-					}
 
-					allocated := false
-					for _, a := range allocs {
-						if a.Space == cap.Nb().Space {
-							allocated = true
-							break
-						}
-					}
-
-					received := false
-					// check if we received the blob (only possible if we have an allocation)
-					if len(allocs) > 0 {
-						if storageService.PDP() != nil {
-							_, err = storageService.PDP().PieceFinder().FindPiece(ctx, digest, cap.Nb().Blob.Size)
-						} else {
-							_, err = storageService.Blobs().Store().Get(ctx, digest)
-						}
-						if err == nil {
-							received = true
-						}
-						if err != nil && !errors.Is(err, store.ErrNotFound) {
-							log.Errorf("getting blob: %w", err)
-							return blob.AllocateOk{}, nil, failure.FromError(err)
-						}
-					}
-
-					// the size reported in the receipt is the number of bytes allocated
-					// in the space - if a previous allocation already exists, this has
-					// already been done, so the allocation size is 0
-					size := cap.Nb().Blob.Size
-					if allocated {
-						size = 0
-					}
-
-					// nothing to do
-					if allocated && received {
-						return blob.AllocateOk{Size: size}, nil, nil
-					}
-
+					// enforce max upload size requirements
 					if cap.Nb().Blob.Size > maxUploadSize {
 						return blob.AllocateOk{}, nil, NewBlobSizeLimitExceededError(cap.Nb().Blob.Size, maxUploadSize)
 					}
 
-					expiresIn := uint64(60 * 60 * 24) // 1 day
-					expiresAt := uint64(time.Now().Unix()) + expiresIn
+					//
+					// end UCAN Validation
+					//
 
-					var address *blob.Address
-					// if not received yet, we need to generate a signed URL for the
-					// upload, and include it in the receipt.
-					if !received {
-						var url url.URL
-						headers := http.Header{}
-						if storageService.PDP() == nil {
-							// use standard blob upload
-							url, headers, err = storageService.Blobs().Presigner().SignUploadURL(ctx, digest, cap.Nb().Blob.Size, expiresIn)
-							if err != nil {
-								log.Errorf("signing upload URL: %w", err)
-								return blob.AllocateOk{}, nil, failure.FromError(err)
-							}
-						} else {
-							// use pdp service upload
-							urlP, err := storageService.PDP().PieceAdder().AddPiece(ctx, digest, cap.Nb().Blob.Size)
-							if err != nil {
-								log.Errorf("adding to pdp service: %w", err)
-								return blob.AllocateOk{}, nil, failure.FromError(err)
-							}
-							url = *urlP
-						}
-						address = &blob.Address{
-							URL:     url,
-							Headers: headers,
-							Expires: expiresAt,
-						}
-					}
-
-					// even if a previous allocation was made in this space, we create
-					// another for the new invocation.
-					err = storageService.Blobs().Allocations().Put(ctx, allocation.Allocation{
-						Space:   cap.Nb().Space,
-						Blob:    allocation.Blob(cap.Nb().Blob),
-						Expires: expiresAt,
-						Cause:   inv.Link(),
+					// FIXME: use a real context, requires changes to server
+					ctx := context.TODO()
+					resp, err := blobAllocate(ctx, storageService, &BlobAllocateRequest{
+						Space:           cap.Nb().Space,
+						Blob:            cap.Nb().Blob,
+						AllocationCause: cap.Nb().Cause,
+						InvocationCause: inv.Link(),
 					})
 					if err != nil {
-						log.Errorf("putting allocation: %w", err)
 						return blob.AllocateOk{}, nil, failure.FromError(err)
 					}
 
-					a, err := storageService.Blobs().Allocations().List(ctx, cap.Nb().Blob.Digest)
-					if err != nil {
-						return blob.AllocateOk{}, nil, failure.FromError(err)
-					}
-					if len(a) < 1 {
-						return blob.AllocateOk{}, nil, failure.FromError(errors.New("failed to read allocation after write"))
-					}
-					log.Info("successfully read allocation after write")
-
-					return blob.AllocateOk{Size: size, Address: address}, nil, nil
+					return blob.AllocateOk{
+						Size:    resp.Size,
+						Address: resp.Address,
+					}, nil, nil
 				},
 			),
 		),
@@ -159,57 +72,42 @@ func NewUCANServer(storageService Service, options ...server.Option) (server.Ser
 			server.Provide(
 				blob.Accept,
 				func(cap ucan.Capability[blob.AcceptCaveats], inv invocation.Invocation, iCtx server.InvocationContext) (blob.AcceptOk, fx.Effects, error) {
-					ctx := context.TODO()
-					digest := cap.Nb().Blob.Digest
-					log := log.With("blob", digestutil.Format(digest))
-					log.Infof("%s %s", blob.AcceptAbility, cap.Nb().Space)
+					//
+					// UCAN Validation
+					//
 
 					// only service principal can perform an allocation
 					if cap.With() != iCtx.ID().DID().String() {
 						return blob.AcceptOk{}, nil, NewUnsupportedCapabilityError(cap)
 					}
 
-					var loc url.URL
+					//
+					// end UCAN Validation
+					//
+
+					// FIXME: use a real context, requires changes to server
+					ctx := context.TODO()
+					resp, err := blobAccept(ctx, storageService, &BlobAcceptRequest{
+						Space: cap.Nb().Space,
+						Blob:  cap.Nb().Blob,
+						Put:   cap.Nb().Put,
+					})
+					if err != nil {
+						return blob.AcceptOk{}, nil, failure.FromError(err)
+					}
 
 					var forks []fx.Effect
-					var pdpLink *ucan.Link
-					if storageService.PDP() == nil {
-						_, err := storageService.Blobs().Store().Get(ctx, digest)
-						if err != nil {
-							if errors.Is(err, store.ErrNotFound) {
-								return blob.AcceptOk{}, nil, NewAllocatedMemoryNotWrittenError()
-							}
-							log.Errorf("getting blob: %w", err)
-							return blob.AcceptOk{}, nil, failure.FromError(err)
-						}
+					forks = append(forks, fx.FromInvocation(resp.Claim))
 
-						loc, err = storageService.Blobs().Access().GetDownloadURL(digest)
-						if err != nil {
-							log.Errorf("creating retrieval URL for blob: %w", err)
-							return blob.AcceptOk{}, nil, failure.FromError(err)
-						}
-					} else {
-						// locate the piece from the pdp service
-						piece, err := storageService.PDP().PieceFinder().FindPiece(ctx, digest, cap.Nb().Blob.Size)
-						if err != nil {
-							log.Errorf("finding piece for blob: %w", err)
-							return blob.AcceptOk{}, nil, failure.FromError(err)
-						}
-						// get a download url
-						loc = storageService.PDP().PieceFinder().URLForPiece(piece)
-						// submit the piece for aggregation
-						err = storageService.PDP().Aggregator().AggregatePiece(ctx, piece)
-						if err != nil {
-							log.Errorf("submitting piece for aggregation: %w", err)
-							return blob.AcceptOk{}, nil, failure.FromError(err)
-						}
+					var pdpLink *ucan.Link
+					if resp.Piece != nil {
 						// generate the invocation that will complete when aggregation is complete and the piece is accepted
 						pieceAccept, err := pdp.Accept.Invoke(
 							storageService.ID(),
 							storageService.ID(),
 							storageService.ID().DID().String(),
 							pdp.AcceptCaveats{
-								Piece: piece,
+								Piece: *resp.Piece,
 							}, delegation.WithNoExpiration())
 						if err != nil {
 							log.Errorf("creating piece accept invocation: %w", err)
@@ -219,36 +117,8 @@ func NewUCANServer(storageService Service, options ...server.Option) (server.Ser
 						pdpLink = &pieceAcceptLink
 						forks = append(forks, fx.FromInvocation(pieceAccept))
 					}
-					claim, err := assert.Location.Delegate(
-						storageService.ID(),
-						cap.Nb().Space,
-						storageService.ID().DID().String(),
-						assert.LocationCaveats{
-							Space:    cap.Nb().Space,
-							Content:  types.FromHash(digest),
-							Location: []url.URL{loc},
-						},
-						delegation.WithNoExpiration(),
-					)
-					if err != nil {
-						log.Errorf("creating location commitment: %w", err)
-						return blob.AcceptOk{}, nil, failure.FromError(err)
-					}
-					forks = append(forks, fx.FromInvocation(claim))
 
-					err = storageService.Claims().Store().Put(ctx, claim)
-					if err != nil {
-						log.Errorf("putting location claim for blob: %w", err)
-						return blob.AcceptOk{}, nil, failure.FromError(err)
-					}
-
-					err = storageService.Claims().Publisher().Publish(ctx, claim)
-					if err != nil {
-						log.Errorf("publishing location commitment: %w", err)
-						return blob.AcceptOk{}, nil, failure.FromError(err)
-					}
-
-					return blob.AcceptOk{Site: claim.Link(), PDP: pdpLink}, fx.NewEffects(fx.WithFork(forks...)), nil
+					return blob.AcceptOk{Site: resp.Claim.Link(), PDP: pdpLink}, fx.NewEffects(fx.WithFork(forks...)), nil
 				},
 			),
 		),

--- a/pkg/service/storage/ucan.go
+++ b/pkg/service/storage/ucan.go
@@ -96,8 +96,7 @@ func NewUCANServer(storageService Service, options ...server.Option) (server.Ser
 						return blob.AcceptOk{}, nil, failure.FromError(err)
 					}
 
-					var forks []fx.Effect
-					forks = append(forks, fx.FromInvocation(resp.Claim))
+					forks := []fx.Effect{fx.FromInvocation(resp.Claim)}
 
 					var pdpLink *ucan.Link
 					if resp.Piece != nil {


### PR DESCRIPTION
- Moves blob allocation and acceptance logic out of ucan.go to blob_allocate.go and blob_accept.go
- Separates UCAN validation, receipts, and effects from blob-specific operations
- Facilitates reuse of UCAN methods for the replication protocol
- In https://github.com/storacha/storage/pull/57 I ended up needing to refactor things here further, but this lays the ground work for the change.