### PR TITLE
fix(ci): release-binaries workflow permissions

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -6,6 +6,10 @@ on:
   workflow_run:
     workflows: [Releaser]
     types: [completed]
+
+permissions:
+  contents: write
+
 jobs:
   bin-releaser:
     name: Release Binaries


### PR DESCRIPTION
requires write on contents permission to fix this error: https://github.com/storacha/storage/actions/runs/14766300763/job/41458325127