### PR TITLE
fix: consistent read for allocations

### DIFF
--- a/pkg/aws/dynamoallocationstore.go
+++ b/pkg/aws/dynamoallocationstore.go
@@ -43,6 +43,7 @@ func (d *DynamoAllocationStore) List(ctx context.Context, mh multihash.Multihash
 		ExpressionAttributeNames:  expr.Names(),
 		ExpressionAttributeValues: expr.Values(),
 		KeyConditionExpression:    expr.KeyCondition(),
+		ConsistentRead:            aws.Bool(true),
 	})
 	for queryPaginator.HasMorePages() {
 		response, err := queryPaginator.NextPage(ctx)


### PR DESCRIPTION
I keep seeing this error in the integration tests:

```
service handler {can: "blob/allocate"} error: failed to read allocation after write
```

From here: https://github.com/storacha/storage/blob/2257b678a2bc9755acd6b77a7b2b52e5c4ace5e1/pkg/service/storage/handlers/blob/allocate.go#L149

I think this check is redundant but we don't want reads to _not_ be strongly consistent for allocations.

