### PR TITLE
fix: use correct dir for pdp storage dir

### DIFF
--- a/pkg/pdp/server.go
+++ b/pkg/pdp/server.go
@@ -104,8 +104,8 @@ func NewServer(
 		return nil, fmt.Errorf("connecting to eth client: %w", err)
 	}
 
-	stateDir, err := os.MkdirTemp(dataDir, "state")
-	if err != nil {
+	stateDir := filepath.Join(dataDir, "state")
+	if err := os.Mkdir(stateDir, 0755); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
- previously a typo caused the storage dir to be a temp dir, which really messed up note restarts as a new path and database was used/inited each time.