### PR TITLE
fix: tasks are retried correctly when they fail

### DIFF
--- a/pkg/pdp/scheduler/handler.go
+++ b/pkg/pdp/scheduler/handler.go
@@ -203,6 +203,7 @@ retryHandleDoneTask:
 				// to pick it back up and try again
 				if err := tx.Model(&models.Task{}).
 					Where(&models.Task{ID: int64(id)}).
+					Select("session_id", "retries", "update_time").
 					Updates(models.Task{
 						SessionID:  nil,
 						Retries:    task.Retries + 1,


### PR DESCRIPTION
**The Problem:** Without the .Select() clause, GORM's Updates() method skips fields with nil/zero values by default to prevent accidentally nullifying fields. When a task failed, the code was trying to set SessionID to nil to mark it as available for retry, but GORM was ignoring this update.

**Why This Matters**: Tasks are picked up by the scheduler based on having a nil SessionID. If the SessionID remains set after a failure, the task appears to still be "in progress" by that session and won't be retried by any worker.

**The Solution**: By explicitly using .Select("session_id", "retries", "update_time"), you force GORM to update these specific fields regardless of their values, ensuring SessionID gets set to nil.
