### PR TITLE
feat: make build date more human-friendly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION=$(shell awk -F'"' '/"version":/ {print $$4}' version.json)
 COMMIT=$(shell git rev-parse --short HEAD)
-DATE=$(shell date -u '+%s')
+DATE=$(shell date -u -Iseconds)
 GOFLAGS=-ldflags="-X github.com/storacha/piri/pkg/build.version=$(VERSION) -X github.com/storacha/piri/pkg/build.Commit=$(COMMIT) -X github.com/storacha/piri/pkg/build.Date=$(DATE) -X github.com/storacha/piri/pkg/build.BuiltBy=make"
 TAGS?=
 


### PR DESCRIPTION
Produce a more human-friendly representation for build dates.
```shell
 λ ./piri version
version: v0.0.9-32e18a8
commit: 32e18a8
built at: 2025-07-16T16:37:21+00:00
built by: make
```