### PR TITLE
refactor: migrate service http handlers to echo

### DIFF
--- a/pkg/service/blobs/server.go
+++ b/pkg/service/blobs/server.go
@@ -9,8 +9,10 @@ import (
 	"time"
 
 	logging "github.com/ipfs/go-log/v2"
+	"github.com/labstack/echo/v4"
 	"github.com/multiformats/go-multibase"
 	"github.com/multiformats/go-multihash"
+
 	"github.com/storacha/piri/internal/telemetry"
 	"github.com/storacha/piri/pkg/presigner"
 	"github.com/storacha/piri/pkg/store/allocationstore"
@@ -29,9 +31,9 @@ func NewServer(presigner presigner.RequestPresigner, allocs allocationstore.Allo
 	return &Server{blobs, presigner, allocs}, nil
 }
 
-func (srv *Server) Serve(mux *http.ServeMux) {
-	mux.Handle("GET /blob/{blob}", NewBlobGetHandler(srv.blobs))
-	mux.Handle("PUT /blob/{blob}", NewBlobPutHandler(srv.presigner, srv.allocs, srv.blobs))
+func (srv *Server) RegisterRoutes(e *echo.Echo) {
+	e.GET("/blob/:blob", echo.WrapHandler(NewBlobGetHandler(srv.blobs)))
+	e.PUT("/blob/:blob", echo.WrapHandler(NewBlobPutHandler(srv.presigner, srv.allocs, srv.blobs)))
 }
 
 func NewBlobGetHandler(blobs blobstore.Blobstore) http.Handler {

--- a/pkg/service/blobs/server_test.go
+++ b/pkg/service/blobs/server_test.go
@@ -14,19 +14,21 @@ import (
 	"time"
 
 	"github.com/ipfs/go-datastore"
+	"github.com/labstack/echo/v4"
 	"github.com/multiformats/go-multihash"
 	ed25519 "github.com/storacha/go-ucanto/principal/ed25519/signer"
+	"github.com/stretchr/testify/require"
+
 	"github.com/storacha/piri/pkg/internal/digestutil"
 	"github.com/storacha/piri/pkg/internal/testutil"
 	"github.com/storacha/piri/pkg/presigner"
 	"github.com/storacha/piri/pkg/store/allocationstore"
 	"github.com/storacha/piri/pkg/store/allocationstore/allocation"
 	"github.com/storacha/piri/pkg/store/blobstore"
-	"github.com/stretchr/testify/require"
 )
 
 func TestServer(t *testing.T) {
-	mux := http.NewServeMux()
+	mux := echo.New()
 	httpsrv := httptest.NewServer(mux)
 	t.Cleanup(httpsrv.Close)
 
@@ -53,7 +55,7 @@ func TestServer(t *testing.T) {
 	srv, err := NewServer(presigner, allocs, blobs)
 	require.NoError(t, err)
 
-	srv.Serve(mux)
+	srv.RegisterRoutes(mux)
 
 	t.Run("get blob", func(t *testing.T) {
 		data := testutil.RandomBytes(t, 32)

--- a/pkg/service/claims/server.go
+++ b/pkg/service/claims/server.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/ipfs/go-cid"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/labstack/echo/v4"
+
 	"github.com/storacha/piri/internal/telemetry"
 	"github.com/storacha/piri/pkg/store"
 	"github.com/storacha/piri/pkg/store/claimstore"
@@ -22,8 +24,8 @@ func NewServer(claims claimstore.ClaimStore) (*Server, error) {
 	return &Server{claims}, nil
 }
 
-func (srv *Server) Serve(mux *http.ServeMux) {
-	mux.Handle("GET /claim/{claim}", NewHandler(srv.claims))
+func (srv *Server) RegisterRoutes(e *echo.Echo) {
+	e.GET("/claim/:claim", echo.WrapHandler(NewHandler(srv.claims)))
 }
 
 func NewHandler(claims claimstore.ClaimStore) http.Handler {

--- a/pkg/service/publisher/server.go
+++ b/pkg/service/publisher/server.go
@@ -2,8 +2,8 @@ package publisher
 
 import (
 	"fmt"
-	"net/http"
 
+	"github.com/labstack/echo/v4"
 	"github.com/storacha/go-libstoracha/ipnipublisher/server"
 	"github.com/storacha/go-libstoracha/ipnipublisher/store"
 )
@@ -20,6 +20,7 @@ func NewServer(store store.EncodeableStore) (*Server, error) {
 	return &Server{server}, nil
 }
 
-func (srv *Server) Serve(mux *http.ServeMux) {
-	mux.HandleFunc(fmt.Sprintf("GET %s/{ad}", server.IPNIPath), srv.server.ServeHTTP)
+func (srv *Server) RegisterRoutes(e *echo.Echo) {
+	route := fmt.Sprintf("%s/:ad", server.IPNIPath)
+	e.GET(route, echo.WrapHandler(srv.server))
 }

--- a/pkg/service/storage/server.go
+++ b/pkg/service/storage/server.go
@@ -5,8 +5,10 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/labstack/echo/v4"
 	"github.com/storacha/go-ucanto/server"
 	ucanhttp "github.com/storacha/go-ucanto/transport/http"
+
 	"github.com/storacha/piri/internal/telemetry"
 )
 
@@ -23,8 +25,8 @@ func NewServer(service Service, options ...server.Option) (*Server, error) {
 	return &Server{ucanSrv}, nil
 }
 
-func (srv *Server) Serve(mux *http.ServeMux) {
-	mux.Handle("POST /", NewHandler(srv.ucanServer))
+func (srv *Server) RegisterRoutes(e *echo.Echo) {
+	e.POST("/", echo.WrapHandler(NewHandler(srv.ucanServer)))
 }
 
 func NewHandler(server server.ServerView) http.Handler {


### PR DESCRIPTION
- the PDP server currently uses echo, align on a single impl for easier dep injection follow on
- mechanical change, extracted from https://github.com/storacha/piri/pull/144
- follows https://github.com/storacha/piri/pull/160