### PR TITLE
feat: validate indexer `claim/cache` delegation

### DIFF
--- a/pkg/principalresolver/httpresolver.go
+++ b/pkg/principalresolver/httpresolver.go
@@ -176,8 +176,6 @@ func NewHTTPResolver(webKeys []did.DID, opts ...Option) (*HTTPResolver, error) {
 	return resolver, nil
 }
 
-// TODO(forrest): the interface this implements in go-ucanto should probably accept a context
-// since means of resolution here are open ended, and may go to network or disk.
 func (r *HTTPResolver) ResolveDIDKey(ctx context.Context, input did.DID) (did.DID, validator.UnresolvedDID) {
 	endpoint, ok := r.webKeys[input]
 	if !ok {


### PR DESCRIPTION
This PR adds a validation method for the configured delegation that enables piri nodes to cache claims with the indexer.

The delegation is validated at server startup to prevent failures from occurring _after_ data is stored on the node.

The delegation is validated by calling the ucanto validator `Access` method with a dummy invocation.