### PR TITLE
fix(docs): add --public-url flag to serve ucan command and prefix env…

### DIFF
--- a/docs/guides/ucan-server.md
+++ b/docs/guides/ucan-server.md
@@ -66,11 +66,11 @@ Create a `.env` file with the configuration received:
 
 ```bash
 # Example .env file
-export INDEXING_SERVICE_DID="did:web:staging.indexer.warm.storacha.network"
-export INDEXING_SERVICE_URL="https://staging.indexer.warm.storacha.network/claims"
-export INDEXING_SERVICE_PROOF="mAYIEA..."
-export UPLOAD_SERVICE_DID="did:web:staging.upload.warm.storacha.network"
-export UPLOAD_SERVICE_URL="https://staging.upload.warm.storacha.network"
+export PIRI_INDEXING_SERVICE_DID="did:web:staging.indexer.warm.storacha.network"
+export PIRI_INDEXING_SERVICE_URL="https://staging.indexer.warm.storacha.network/claims"
+export PIRI_INDEXING_SERVICE_PROOF="mAYIEA..."
+export PIRI_UPLOAD_SERVICE_DID="did:web:staging.upload.warm.storacha.network"
+export PIRI_UPLOAD_SERVICE_URL="https://staging.upload.warm.storacha.network"
 ...
 ```
 
@@ -83,11 +83,11 @@ source .env
 #### 4.3 Restart your Piri node
 
 ```bash
-piri serve ucan --key-file=service.pem --pdp-server-url=https://up.piri.example.com --proof-set=123
+piri serve ucan --key-file=service.pem --public-url=https://piri.example.com --pdp-server-url=https://up.piri.example.com --proof-set=123
 ```
 
 > **Note**:
-> - Replace `up.piri.example.com` with your actual PDP server domain configured in the [TLS Termination](../setup/tls-termination.md) section.
+> - Replace `piri.example.com` and `up.piri.example.com` with your actual UCAN server and PDP server domains, respectively. These are the domains you configured in the [TLS Termination](../setup/tls-termination.md) section.
 > - Replace `123` with the proof set ID you got when [a new proofset was created](./pdp-server.md#step-3-create-a-proof-set) as part of configuring the PDP server.
 
 **Expected output:**


### PR DESCRIPTION
a couple more tweaks to the UCAN server guide coming from my experience running the node.