### PR TITLE
fix: specify range in location commitment

### DIFF
--- a/pkg/service/storage/handlers/blob/accept.go
+++ b/pkg/service/storage/handlers/blob/accept.go
@@ -99,6 +99,7 @@ func Accept(ctx context.Context, s AcceptService, req *AcceptRequest) (*AcceptRe
 		pdpAcceptInv = pieceAccept
 	}
 
+	byteRange := assert.Range{Offset: 0, Length: &req.Blob.Size}
 	claim, err := assert.Location.Delegate(
 		s.ID(),
 		req.Space,
@@ -107,6 +108,7 @@ func Accept(ctx context.Context, s AcceptService, req *AcceptRequest) (*AcceptRe
 			Space:    req.Space,
 			Content:  types.FromHash(req.Blob.Digest),
 			Location: []url.URL{loc},
+			Range:    &byteRange,
 		},
 		delegation.WithNoExpiration(),
 	)


### PR DESCRIPTION
This PR adds the byte range of the blob to the location commitment. It allows retrievals without having to trust the storage node to provide the byte range.

i.e. it allows us to invoke `space/content/retrieve` with a byte range so that we don't trust the storage node to report the bytes served on it's own.

This is also consistent with location commitments issued by the legacy upload service.