### PR TITLE
refactor: hide auto update commands till ready

### DIFF
--- a/cmd/cli/setup/install.go
+++ b/cmd/cli/setup/install.go
@@ -30,8 +30,9 @@ Requirements:
 
 Automatic updates check for new releases every 30 minutes and apply them when
 safe to do so (not during proof generation or active transfers).`,
-	Args: cobra.NoArgs,
-	RunE: runInstall,
+	Args:   cobra.NoArgs,
+	RunE:   runInstall,
+	Hidden: true,
 }
 
 func init() {

--- a/cmd/cli/setup/uninstall.go
+++ b/cmd/cli/setup/uninstall.go
@@ -25,8 +25,9 @@ To completely remove piri, manually delete /opt/piri after uninstalling.
 Requirements:
   - Linux operating system with systemd
   - Root privileges (run with sudo)`,
-	Args: cobra.NoArgs,
-	RunE: runUninstall,
+	Args:   cobra.NoArgs,
+	RunE:   runUninstall,
+	Hidden: true,
 }
 
 func init() {


### PR DESCRIPTION
Hidden till code stabilizes around contracts/breaking changes. 