### PR TITLE
fix: return the error

### DIFF
--- a/pkg/service/publisher/publisher.go
+++ b/pkg/service/publisher/publisher.go
@@ -111,7 +111,7 @@ func PublishLocationCommitment(
 		if err != nil && errors.Is(err, ipnipub.ErrAlreadyAdvertised) {
 			return nil, backoff.Permanent(err)
 		}
-		return l, nil
+		return l, err
 	}, backoff.WithMaxTries(maxPublishAttempts))
 	if err != nil {
 		if errors.Is(err, ipnipub.ErrAlreadyAdvertised) {


### PR DESCRIPTION
🤦‍♂️ all that work and it isn't even retrying when it fails so we're still generating orphans.