### PR TITLE
 feat: add dead letter queue and PermanentError support

### DIFF
--- a/pkg/pdp/aggregator/jobqueue/internal/testing/schema.sql
+++ b/pkg/pdp/aggregator/jobqueue/internal/testing/schema.sql
@@ -20,3 +20,20 @@ create trigger jobqueue_updated_timestamp after update on jobqueue begin
 end;
 
 create index jobqueue_queue_created_idx on jobqueue (queue, created);
+
+-- Dead letter queue for permanently failed jobs
+create table if not exists jobqueue_dead (
+    id text primary key,
+    created text not null,
+    updated text not null,
+    queue text not null,
+    body blob not null,
+    timeout text not null,
+    received integer not null,
+    job_name text not null,
+    failure_reason text not null,
+    error_message text not null,
+    moved_at text not null default (strftime('%Y-%m-%dT%H:%M:%fZ'))
+) strict;
+
+create index if not exists jobqueue_dead_queue_moved_at_idx on jobqueue_dead (queue, moved_at);

--- a/pkg/pdp/aggregator/jobqueue/jobqueue.go
+++ b/pkg/pdp/aggregator/jobqueue/jobqueue.go
@@ -212,3 +212,8 @@ func (j *JobQueue[T]) Stop(ctx context.Context) error {
 func WithOnFailure[T any](onFailure worker.OnFailureFn[T]) worker.JobOption[T] {
 	return worker.WithOnFailure[T](onFailure)
 }
+
+// NewPermanentError creates an error that will prevent the job queue from retrying the job
+func NewPermanentError(err error) error {
+	return worker.Permanent(err)
+}

--- a/pkg/pdp/aggregator/jobqueue/queue/schema.sql
+++ b/pkg/pdp/aggregator/jobqueue/queue/schema.sql
@@ -20,3 +20,20 @@ create trigger if not exists jobqueue_updated_timestamp after update on jobqueue
 end;
 
 create index if not exists jobqueue_queue_created_idx on jobqueue (queue, created);
+
+-- Dead letter queue for permanently failed jobs
+create table if not exists jobqueue_dead (
+    id text primary key,
+    created text not null,
+    updated text not null,
+    queue text not null,
+    body blob not null,
+    timeout text not null,
+    received integer not null,
+    job_name text not null,
+    failure_reason text not null,
+    error_message text not null,
+    moved_at text not null default (strftime('%Y-%m-%dT%H:%M:%fZ'))
+) strict;
+
+create index if not exists jobqueue_dead_queue_moved_at_idx on jobqueue_dead (queue, moved_at);

--- a/pkg/pdp/aggregator/jobqueue/worker/errors.go
+++ b/pkg/pdp/aggregator/jobqueue/worker/errors.go
@@ -1,0 +1,26 @@
+package worker
+
+// PermanentError signals that the operation should not be retried.
+type PermanentError struct {
+	Err error
+}
+
+// Permanent wraps the given err in a *PermanentError.
+func Permanent(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &PermanentError{
+		Err: err,
+	}
+}
+
+// Error returns a string representation of the Permanent error.
+func (e *PermanentError) Error() string {
+	return e.Err.Error()
+}
+
+// Unwrap returns the wrapped error.
+func (e *PermanentError) Unwrap() error {
+	return e.Err
+}


### PR DESCRIPTION
## Motivation
There are times where jobs need not be retried with a job queue, an example is when adding a root to a dataset that is uninitialized, we shouldn't keep trying. Or when signing a root fails due to invalid payload, no point trying again. 

We also don't want failed jobs to sit around in the main queue forever as that will impact performance, so now we put them in a dead letter queue, which follows convention for this sort of queue system.

This change sets us up for future work to land from new contracts

## What?

Add dead letter queue functionality to move failed jobs after max retries or permanent errors:
 - Add dead_letter_queue table to schema
 - Implement MoveToDeadLetter in queue with failure reason tracking
 - Add PermanentError type to signal non-retryable failures
 - Invoke OnFailure callback for both max retries and PermanentError
 - Refactor worker.receiveAndRun into focused helper methods

Tests:
 - Add dead letter queue tests for permanent and max retry failures
 - Add PermanentError tests verifying no retries and error unwrapping
 - Add OnFailure callback tests for PermanentError path
 
## Future consideration

At some we will want to expose the contents of these queues to node operators to gauge health of operation. 

We will also want to add GC to the dead_letter queue so save space.