### PR TITLE
chore: smaller egress tracking batches for testing

### DIFF
--- a/cmd/cli/setup/register.go
+++ b/cmd/cli/setup/register.go
@@ -350,7 +350,8 @@ func generateConfig(cfg *appcfg.AppConfig, flags *initFlags, ownerAddress common
 					Proof: indexerProof,
 				},
 				EgressTracker: config.EgressTrackerServiceConfig{
-					Proof: egressTrackerProof,
+					Proof:             egressTrackerProof,
+					MaxBatchSizeBytes: 10 * 1024,
 				},
 			},
 			ProofSetID: proofSetID,


### PR DESCRIPTION
Set batch size to 10KiB in the default config so that nodes produce batches more frequently during testing.

This is a follow-up to #296. I'll rebase on main once that one's merged.