### PR TITLE
feat: point to the registrar service at its new location

### DIFF
--- a/cmd/cli/setup/register.go
+++ b/cmd/cli/setup/register.go
@@ -51,7 +51,7 @@ var InitCmd = &cobra.Command{
 }
 
 func init() {
-	InitCmd.Flags().String("registrar-url", "https://staging.registrar.storacha.network", "URL of the registrar service")
+	InitCmd.Flags().String("registrar-url", "https://staging.registrar.warm.storacha.network", "URL of the registrar service")
 	cobra.CheckErr(InitCmd.Flags().MarkHidden("registrar-url"))
 
 	InitCmd.Flags().String("data-dir", "", "Path to a data directory Piri will maintain its permanent state in")

--- a/deploy/full-node/deployment-types/multi-instance/tofu.tfvars.template
+++ b/deploy/full-node/deployment-types/multi-instance/tofu.tfvars.template
@@ -114,8 +114,8 @@ pdp_lotus_endpoint = "wss://YOUR_LOTUS_ENDPOINT/rpc/v1"
 # pdp_contract_address = "0x6170dE2b09b404776197485F3dc6c968Ef948505"
 
 # Registrar service URL for node registration
-# Default: "https://staging.registrar.storacha.network" - uncomment to override
-# registrar_url = "https://staging.registrar.storacha.network"
+# Default: "https://staging.registrar.warm.storacha.network" - uncomment to override
+# registrar_url = "https://staging.registrar.warm.storacha.network"
 
 # ===========================================================================
 # SECRETS MANAGEMENT

--- a/deploy/full-node/deployment-types/multi-instance/variables.tf
+++ b/deploy/full-node/deployment-types/multi-instance/variables.tf
@@ -76,7 +76,7 @@ variable "default_install_source" {
 variable "registrar_url" {
   description = "URL of the registrar service for node registration"
   type        = string
-  default     = "https://staging.registrar.storacha.network"
+  default     = "https://staging.registrar.warm.storacha.network"
 }
 
 variable "pdp_lotus_endpoint" {

--- a/deploy/full-node/deployment-types/single-instance/tofu.tfvars.template
+++ b/deploy/full-node/deployment-types/single-instance/tofu.tfvars.template
@@ -155,8 +155,8 @@ pdp_lotus_endpoint = "wss://YOUR_LOTUS_ENDPOINT/rpc/v1"
 # pdp_contract_address = "0x6170dE2b09b404776197485F3dc6c968Ef948505"
 
 # Registrar service URL for node registration
-# Default: "https://staging.registrar.storacha.network" - uncomment to override
-# registrar_url = "https://staging.registrar.storacha.network"
+# Default: "https://staging.registrar.warm.storacha.network" - uncomment to override
+# registrar_url = "https://staging.registrar.warm.storacha.network"
 
 # ===========================================================================
 # OPERATOR CONFIGURATION

--- a/deploy/full-node/deployment-types/single-instance/variables.tf
+++ b/deploy/full-node/deployment-types/single-instance/variables.tf
@@ -84,7 +84,7 @@ variable "install_source" {
 variable "registrar_url" {
   description = "URL of the registrar service for node registration"
   type        = string
-  default     = "https://staging.registrar.storacha.network"
+  default     = "https://staging.registrar.warm.storacha.network"
 }
 
 variable "pdp_lotus_endpoint" {

--- a/deploy/full-node/modules/piri-instance/variables.tf
+++ b/deploy/full-node/modules/piri-instance/variables.tf
@@ -86,7 +86,7 @@ variable "install_source" {
 variable "registrar_url" {
   description = "URL of the registrar service for node registration"
   type        = string
-  default     = "https://staging.registrar.storacha.network"
+  default     = "https://staging.registrar.warm.storacha.network"
 }
 
 variable "pdp_lotus_endpoint" {


### PR DESCRIPTION
The registrar service has been deployed to the standard `warm.storacha.network` domain.