### PR TITLE
fix: only track egress caused by space/content/retrieve invocations

### DIFF
--- a/pkg/fx/retrieval/ucan/handlers/provider.go
+++ b/pkg/fx/retrieval/ucan/handlers/provider.go
@@ -52,12 +52,7 @@ func withErrorHandler() ucanretrieval.Option {
 
 func withReceiptLogger(ets *egresstracker.Service) ucanretrieval.Option {
 	return ucanretrieval.WithReceiptLogger(func(_ context.Context, rcpt receipt.AnyReceipt, inv invocation.Invocation) error {
-		// Egress tracking is optional, the service will be nil if it is disabled
-		if ets == nil {
-			log.Warn("Egress tracking is not configured")
-			return nil
-		}
-
+		// Filter out capabilities that are not space/content/retrieve
 		if len(inv.Capabilities()) != 1 {
 			log.Warn("Expected exactly one capability in invocation")
 			return nil
@@ -66,6 +61,12 @@ func withReceiptLogger(ets *egresstracker.Service) ucanretrieval.Option {
 		capability := inv.Capabilities()[0]
 		if capability.Can() != content.RetrieveAbility {
 			log.Info("Receipt is for a %s invocation, ignoring", capability.Can())
+			return nil
+		}
+
+		// Egress tracking is optional, the service will be nil if it is disabled
+		if ets == nil {
+			log.Warn("Egress tracking is not configured")
 			return nil
 		}
 


### PR DESCRIPTION
The retrieve server is configured with a receipt logger so that we can collect `space/content/retrieve` receipts. However, the receipt logger is configured for the whole server, which also serves `blob/retrieve` invocations. This PR filters receipts so that only `space/content/retrieve` ones are collected for egress tracking.