### PR TITLE
feat(cli): `piri serve` to start a "full" server

### DIFF
--- a/cmd/cli/serve/root.go
+++ b/cmd/cli/serve/root.go
@@ -11,6 +11,8 @@ var log = logging.Logger("cmd/serve")
 var Cmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Start a server",
+	Args:  cobra.NoArgs,
+	RunE:  fullServer,
 }
 
 func init() {

--- a/cmd/cli/setup/config.go
+++ b/cmd/cli/setup/config.go
@@ -104,7 +104,7 @@ var (
 
 // Service-related constants
 const (
-	PiriServeCommand                  = "serve full"
+	PiriServeCommand                  = "serve"
 	PiriUpdateCommand                 = "update-internal"
 	PiriServiceFile                   = "piri.service"
 	PiriUpdateServiceFile             = "piri-updater.service"

--- a/cmd/cli/setup/installer_test.go
+++ b/cmd/cli/setup/installer_test.go
@@ -238,7 +238,7 @@ func TestInstaller_ServiceFileGeneration(t *testing.T) {
 				"User=testuser",
 				"Group=testuser",
 				"ExecStart=",
-				"serve full",
+				"serve",
 				"TimeoutStopSec=",
 			},
 		},
@@ -348,7 +348,7 @@ func TestServiceConstants(t *testing.T) {
 	require.Equal(t, "piri.service", PiriServiceFile)
 	require.Equal(t, "piri-updater.service", PiriUpdateServiceFile)
 	require.Equal(t, "piri-updater.timer", PiriUpdateTimerServiceFile)
-	require.Equal(t, "serve full", PiriServeCommand)
+	require.Equal(t, "serve", PiriServeCommand)
 	require.Equal(t, "update-internal", PiriUpdateCommand)
 	require.True(t, strings.Contains(ReleaseURL, "github.com"))
 }

--- a/deploy/full-node/modules/piri-instance/files/piri.service.tpl
+++ b/deploy/full-node/modules/piri-instance/files/piri.service.tpl
@@ -23,7 +23,7 @@ ExecStartPre=/bin/bash -c '/usr/local/bin/piri init \
   --public-url="${public_url}" \
   > /etc/piri/config.toml'
 
-ExecStart=/usr/local/bin/piri serve full --config=/etc/piri/config.toml
+ExecStart=/usr/local/bin/piri serve --config=/etc/piri/config.toml
 
 Restart=on-failure
 RestartSec=10

--- a/docs/guides/piri-server.md
+++ b/docs/guides/piri-server.md
@@ -84,7 +84,7 @@ The command creates a complete TOML configuration file. If you didn't save it to
 After setup is complete, run your Piri node using the configuration file:
 
 ```bash
-piri serve full --config=config.toml
+piri serve --config=config.toml
 ```
 
 If the `--config` option is not provided, Piri will automatically load config from your user config directory e.g. `~/.config/piri/config.toml`.

--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -13,7 +13,7 @@ The configuration file is created when you run `piri init`. See the [Piri Node S
 ### Using a Configuration File
 
 ```bash
-piri serve full --config=config.toml
+piri serve --config=config.toml
 ```
 
 ## Configuration File Format

--- a/docs/setup/upgrading.md
+++ b/docs/setup/upgrading.md
@@ -36,7 +36,7 @@ piri version
 Restart your Piri server using your existing configuration file:
 
 ```bash
-piri serve full --config=config.toml
+piri serve --config=config.toml
 ```
 
 **Note:** Do not run `piri init` when upgrading - your existing configuration and proof set should be preserved.


### PR DESCRIPTION
Retains backwards compatibility.

refs https://github.com/storacha/piri/issues/252