### PR TITLE
fix: increase allowed transfer time

### DIFF
--- a/pkg/service/storage/ucan/replica_allocate.go
+++ b/pkg/service/storage/ucan/replica_allocate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"time"
 
 	"github.com/storacha/go-libstoracha/capabilities/assert"
 	"github.com/storacha/go-libstoracha/capabilities/blob/replica"
@@ -26,7 +27,7 @@ import (
 )
 
 // Time in seconds we allow ourselves to transfer the blob and conclude the task
-const transferTimeout = 60 * 60 // 1h
+const transferTimeout = time.Hour
 
 type ReplicaAllocateService interface {
 	ID() principal.Signer
@@ -104,7 +105,9 @@ func ReplicaAllocate(storageService ReplicaAllocateService) server.Option {
 						Site:  cap.Nb().Site,
 						Cause: inv.Link(),
 					},
-					delegation.WithExpiration(ucan.Now()+transferTimeout),
+					delegation.WithExpiration(
+						ucan.UTCUnixTimestamp(time.Now().Add(transferTimeout).Unix()),
+					),
 				)
 				if err != nil {
 					return nil, nil, err


### PR DESCRIPTION
This PR increases the transfer task expiration from 30 seconds to 1 hour. It allows for queuing delays and retries. This time is effectively the time we give ourselves to transfer the blob and send a `ucan/conclude` invocation to the upload service.

Aims to resolve:

```
'Unauthorized: Claim {"can":"blob/replica/transfer"} is not authorized\n' +
          '  - Proof bafyreig3wen5tsemfffi6u4tfou4y7v2mffajuyujgc53vpvoykbzdf6pe has expired on Thu Oct 30 2025 16:17:30 GMT+0000 (Coordinated Universal Time)\n'
```

...which is the upload service validating the transfer invocation in the `ucan/conclude` invocation.