### PR TITLE
fix: use lifecycle context not background context when stopping aggregate manager

### DIFF
--- a/pkg/pdp/aggregator/aggregate_manager.go
+++ b/pkg/pdp/aggregator/aggregate_manager.go
@@ -148,7 +148,7 @@ func NewManager(lc fx.Lifecycle, params ManagerParams) (*Manager, error) {
 		OnStart: func(ctx context.Context) error {
 			return m.Start()
 		},
-		OnStop: func(context.Context) error {
+		OnStop: func(ctx context.Context) error {
 			return m.Stop(ctx)
 		},
 	})


### PR DESCRIPTION
Resolves:

```
^C2025-10-31T11:36:03.046Z      INFO    cmd/serve       serve/full.go:259       Shutting down piri...this may take up to 1m0s                                                                                    
2025-10-31T11:36:03.046Z        INFO    pdp/aggregator  aggregator/aggregate_manager.go:284     Stopping submission manager                                                                                      
2025-10-31T11:36:03.046Z        ERROR   jobqueue        jobqueue/jobqueue.go:202        JobQueue[manager] stop timeout - some tasks may not have completed gracefully                                            
2025-10-31T11:36:03.046Z        ERROR   cmd/serve       fxevent/zap.go:59       OnStop hook failed      {"callee": "github.com/storacha/piri/pkg/pdp/aggregator.NewManager.func2()", "caller": "github.com/storac
ha/piri/pkg/pdp/aggregator.NewManager", "error": "failed to stop batch queue: stop timeout: context canceled"}
```