### PR TITLE
fix: use lifecycle context not background for egress tracker cleanup

### DIFF
--- a/pkg/service/egresstracker/fx.go
+++ b/pkg/service/egresstracker/fx.go
@@ -163,11 +163,13 @@ func NewEgressTrackerService(
 	}
 
 	// Add lifecycle hooks for cleanup task
+	cleanupCtx, cancel := context.WithCancel(context.Background())
 	lc.Append(fx.Hook{
-		OnStart: func(ctx context.Context) error {
-			return svc.StartCleanupTask(ctx)
+		OnStart: func(context.Context) error {
+			return svc.StartCleanupTask(cleanupCtx)
 		},
 		OnStop: func(ctx context.Context) error {
+			cancel()
 			return svc.StopCleanupTask(ctx)
 		},
 	})


### PR DESCRIPTION
Attempts to resolve this error when hitting `ctrl+c`:

```
2025-10-31T11:59:03.522Z        ERROR   cmd/serve       fxevent/zap.go:59       OnStop hook failed      {"callee": "github.com/storacha/piri/pkg/service/egresstracker.NewEgressTrackerService.func2()", "caller": "github.com/storacha/piri/pkg/service/egresstracker.NewEgressTrackerService", "error": "timeout waiting for cleanup task to stop: context canceled"}
```