### PR TITLE
tests: remove FX deps logs for test setup

### DIFF
--- a/pkg/service/retrieval/ucan_fx_test.go
+++ b/pkg/service/retrieval/ucan_fx_test.go
@@ -32,6 +32,7 @@ func TestFXSpaceContentRetrieve(t *testing.T) {
 
 	appConfig := piritestutil.NewTestConfig(t, piritestutil.WithSigner(testutil.Alice))
 	testApp := fxtest.New(t,
+		fx.NopLogger,
 		app.CommonModules(appConfig),
 		app.UCANModule,
 		fx.Populate(&svc),
@@ -135,6 +136,7 @@ func TestFXBlobRetrieve(t *testing.T) {
 
 	appConfig := piritestutil.NewTestConfig(t, piritestutil.WithSigner(testutil.Alice))
 	testApp := fxtest.New(t,
+		fx.NopLogger,
 		app.CommonModules(appConfig),
 		app.UCANModule,
 		fx.Populate(&svc),

--- a/pkg/service/storage/ucan_access_fx_test.go
+++ b/pkg/service/storage/ucan_access_fx_test.go
@@ -42,6 +42,7 @@ func TestFXAccessGrant(t *testing.T) {
 		piritestutil.WithUploadServiceConfig(upsvc.DID(), testutil.TestURL),
 	)
 	testApp := fxtest.New(t,
+		fx.NopLogger,
 		app.CommonModules(appConfig),
 		app.UCANModule,
 		// use the map resolver so no network calls are made that would fail anyway

--- a/pkg/service/storage/ucan_fx_test.go
+++ b/pkg/service/storage/ucan_fx_test.go
@@ -67,6 +67,7 @@ func TestFXServer(t *testing.T) {
 
 	appConfig := piritestutil.NewTestConfig(t, piritestutil.WithSigner(testutil.Alice))
 	testApp := fxtest.New(t,
+		fx.NopLogger,
 		app.CommonModules(appConfig),
 		app.UCANModule,
 		fx.Populate(&svc, &srv),
@@ -448,6 +449,7 @@ func TestFXReplicaAllocateTransfer(t *testing.T) {
 			)
 
 			testApp := fxtest.New(t,
+				fx.NopLogger,
 				app.CommonModules(appConfig),
 				app.UCANModule,
 				// replace the RequestPresigner with our fake one.


### PR DESCRIPTION
These have been driving me nuts and make CI logs too verbose.