### PR TITLE
fix: do not display usage when init error

### DIFF
--- a/cmd/cli/setup/register.go
+++ b/cmd/cli/setup/register.go
@@ -48,11 +48,10 @@ import (
 var log = logging.Logger("cmd/init")
 
 var InitCmd = &cobra.Command{
-	Use:          "init",
-	Args:         cobra.NoArgs,
-	Short:        "Initialize your piri node in the storacha network",
-	RunE:         doInit,
-	SilenceUsage: true,
+	Use:   "init",
+	Args:  cobra.NoArgs,
+	Short: "Initialize your piri node in the storacha network",
+	RunE:  doInit,
 }
 
 func init() {
@@ -665,6 +664,9 @@ func doInit(cmd *cobra.Command, _ []string) error {
 	cmd.PrintErrln("✅ Configuration validated")
 	cmd.PrintErrln()
 
+	// at this point printing the usage is not needed,
+	//failures after here are unrelated to arguments and flags supplied.
+	cmd.SilenceUsage = true
 	// Step 2: Create and start node
 	cmd.PrintErrln("[2/7] Creating Piri node...")
 	fxApp, pdpSvc, cfg, ownerAddress, err := createNode(ctx, flags)


### PR DESCRIPTION
I *think* this stops cobra from printing the usage text when an error occurs. I think this makes sense here, espeicially when we get a few steps in and it is clear the usage of the command is correct. 

Helpfully undocumented, but you can click through from here to some removed docs for it:
https://github.com/spf13/cobra/issues/225