### PR TITLE
fix: adjust client config

### DIFF
--- a/cmd/cli/client/pdp/proofset/state.go
+++ b/cmd/cli/client/pdp/proofset/state.go
@@ -52,7 +52,7 @@ func doState(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("creating client: %w", err)
 	}
 
-	proofSet, err := api.GetProofSetState(ctx, cfg.UCANService.ProofSetID)
+	proofSet, err := api.GetProofSetState(ctx, cfg.UCAN.ProofSetID)
 	if err != nil {
 		return fmt.Errorf("getting proof set status: %w", err)
 	}

--- a/pkg/config/client.go
+++ b/pkg/config/client.go
@@ -1,9 +1,13 @@
 package config
 
 type Client struct {
-	Identity    IdentityConfig    `mapstructure:"identity"`
-	API         API               `mapstructure:"api"`
-	UCANService UCANServiceConfig `mapstructure:"ucan" toml:"ucan"`
+	Identity IdentityConfig `mapstructure:"identity"`
+	API      API            `mapstructure:"api"`
+	UCAN     UCANConfig     `mapstructure:"ucan" toml:"ucan"`
+}
+
+type UCANConfig struct {
+	ProofSetID uint64 `mapstructure:"proof_set" toml:"proof_set"`
 }
 
 func (c Client) Validate() error {


### PR DESCRIPTION
The `client` family of CLI commands started to fail when we introduced the `network` concept to fetch presets. Instead of making `client` commands `network`-aware, I updated the `config.Client` struct to remove dependencies on settings that are not used.

The only actual config attribute these commands need is `ProofSetID` (and it's just the `pdp proofset state` command), so I'm leaving just that. Keys are respected so that the config is compatible with the current `config.toml` format.