### PR TITLE
fix: write the blob outside of the transaction

### DIFF
--- a/pkg/pdp/service/service.go
+++ b/pkg/pdp/service/service.go
@@ -13,9 +13,9 @@ import (
 	"github.com/storacha/filecoin-services/go/eip712"
 	"github.com/storacha/go-ucanto/ucan"
 	signer "github.com/storacha/piri-signing-service/pkg/types"
-	appconfig "github.com/storacha/piri/pkg/config/app"
 	"gorm.io/gorm"
 
+	appconfig "github.com/storacha/piri/pkg/config/app"
 	"github.com/storacha/piri/pkg/pdp/chainsched"
 	"github.com/storacha/piri/pkg/pdp/ethereum"
 	"github.com/storacha/piri/pkg/pdp/scheduler"
@@ -48,7 +48,7 @@ type PDPService struct {
 	id              ucan.Signer
 	endpoint        url.URL
 	address         common.Address
-	blobstore       blobstore.Blobstore
+	blobstore       blobstore.PDPStore
 	acceptanceStore acceptancestore.AcceptanceStore
 	receiptStore    receiptstore.ReceiptStore
 	sender          ethereum.Sender

--- a/pkg/store/blobstore/interface.go
+++ b/pkg/store/blobstore/interface.go
@@ -101,6 +101,7 @@ type FileSystemer interface {
 
 type PDPStore interface {
 	Blobstore
+	Delete(ctx context.Context, digest multihash.Multihash) error
 }
 
 type GetConfig interface {

--- a/pkg/store/blobstore/objectstore.go
+++ b/pkg/store/blobstore/objectstore.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/multiformats/go-multibase"
 	"github.com/multiformats/go-multihash"
+
 	"github.com/storacha/piri/pkg/store"
 	"github.com/storacha/piri/pkg/store/objectstore"
 )
@@ -43,6 +44,10 @@ func (d *ObjectBlobstore) Get(ctx context.Context, digest multihash.Multihash, o
 
 func (d *ObjectBlobstore) Put(ctx context.Context, digest multihash.Multihash, size uint64, body io.Reader) error {
 	return d.data.Put(ctx, encodeKey(digest), size, body)
+}
+
+func (d *ObjectBlobstore) Delete(ctx context.Context, digest multihash.Multihash) error {
+	return d.data.Delete(ctx, encodeKey(digest))
 }
 
 // Adapted from

--- a/pkg/store/blobstore/todo_datastore.go
+++ b/pkg/store/blobstore/todo_datastore.go
@@ -11,6 +11,7 @@ import (
 	"github.com/multiformats/go-multihash"
 
 	"github.com/storacha/go-libstoracha/digestutil"
+
 	"github.com/storacha/piri/pkg/store"
 )
 
@@ -66,6 +67,10 @@ func (d *TODO_DsBlobstore) Put(ctx context.Context, digest multihash.Multihash, 
 	}
 
 	return nil
+}
+
+func (d *TODO_DsBlobstore) Delete(ctx context.Context, digest multihash.Multihash) error {
+	return d.data.Delete(ctx, datastore.NewKey(digestutil.Format(digest)))
 }
 
 func (d *TODO_DsBlobstore) FileSystem() http.FileSystem {


### PR DESCRIPTION
- else we hold open a transaction for as long as it takes a client to write data to the blobstore, and when streamed over a network this is slow

TODO:
- waiting for @alanshaw to PR change which adds a delete method to the blobstore :)