### PR TITLE
fix: use passed context when stopping not background context

### DIFF
--- a/pkg/pdp/aggregation/aggregator/jobqueue.go
+++ b/pkg/pdp/aggregation/aggregator/jobqueue.go
@@ -55,7 +55,7 @@ func New(lc fx.Lifecycle, params AggregatorParams) (*Aggregator, error) {
 		},
 		OnStop: func(ctx context.Context) error {
 			cancel()
-			return a.queue.Stop(queueCtx)
+			return a.queue.Stop(ctx)
 		},
 	})
 


### PR DESCRIPTION
Fixes:

```
2025-12-02T14:33:39.080Z        ERROR   jobqueue        jobqueue/jobqueue.go:336        JobQueue[aggregator] stop timeout - some tasks may not have completed gracefully
2025-12-02T14:33:39.080Z        ERROR   cmd/serve       fxevent/zap.go:59       OnStop hook failed      {"callee": "github.com/storacha/piri/pkg/pdp/aggregation/aggregator.New.func2()", "caller": "github.com/storacha/piri/pkg/pdp/aggregation/aggregator.New", "error": "stop timeout: context canceled"}
```

Same issue as https://github.com/storacha/piri/pull/319