### PR TITLE
fix: go back to default MaxBatchSizeBytes egress tracker setting

### DIFF
--- a/cmd/cli/setup/register.go
+++ b/cmd/cli/setup/register.go
@@ -639,8 +639,7 @@ func generateConfig(cfg *appcfg.AppConfig, flags *initFlags, ownerAddress common
 					Proof: indexerProof,
 				},
 				EgressTracker: config.EgressTrackerServiceConfig{
-					Proof:             egressTrackerProof,
-					MaxBatchSizeBytes: 10 * 1024,
+					Proof: egressTrackerProof,
 				},
 			},
 			ProofSetID: proofSetID,

--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -113,7 +113,7 @@ type EgressTrackerServiceConfig struct {
 	ReceiptsEndpoint string `mapstructure:"receipts_endpoint" flag:"egress-tracker-service-receipts-endpoint" toml:"receipts_endpoint,omitempty"`
 	// According to the spec, batch size should be between 10MiB and 1GiB
 	// (see https://github.com/storacha/specs/blob/main/w3-egress-tracking.md)
-	MaxBatchSizeBytes int64  `mapstructure:"max_batch_size_bytes" validate:"min=0,max=1073741824" flag:"egress-tracker-service-max-batch-size-bytes" toml:"max_batch_size_bytes,omitempty"`
+	MaxBatchSizeBytes int64  `mapstructure:"max_batch_size_bytes" validate:"min=10485760,max=1073741824" flag:"egress-tracker-service-max-batch-size-bytes" toml:"max_batch_size_bytes,omitempty"`
 	Proof             string `mapstructure:"proof" flag:"egress-tracker-service-proof" toml:"proof,omitempty"`
 }
 


### PR DESCRIPTION
In #297 and #298 I reduced the max size of batches sent to the egress tracker to make testing easier. These are not needed anymore, so let's get them back to the default.