### PR TITLE
fix: never sample unless parent is sampled

### DIFF
--- a/pkg/telemetry/tracer.go
+++ b/pkg/telemetry/tracer.go
@@ -24,6 +24,7 @@ func newTraceProvider(ctx context.Context, res *sdkresource.Resource, opts []otl
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exporter),
 		sdktrace.WithResource(res),
+		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.NeverSample())),
 	)
 
 	otel.SetTracerProvider(tp)


### PR DESCRIPTION
Configures the trace provider to not sample unless the parent is sampled.

Currently Piri will always sample if there is no parent.