### PR TITLE
fix: pass client config to client status

### DIFF
--- a/pkg/client/status.go
+++ b/pkg/client/status.go
@@ -23,29 +23,19 @@ type NodeStatus struct {
 
 // GetNodeStatus connects to a running piri node and checks its status
 func GetNodeStatus(ctx context.Context) (*NodeStatus, error) {
-	userCfg, err := config.Load[config.FullServerConfig]()
+	cfg, err := config.Load[config.Client]()
 	if err != nil {
 		return nil, fmt.Errorf("loading config: %w", err)
 	}
 
-	appCfg, err := userCfg.ToAppConfig()
-	if err != nil {
-		return nil, fmt.Errorf("parsing config: %w", err)
-	}
-
 	// Create API client to connect to local node
-	api, err := client.NewFromConfig(config.Client{
-		Identity: userCfg.Identity,
-		API: config.API{
-			Endpoint: fmt.Sprintf("http://%s:%d", userCfg.Server.Host, userCfg.Server.Port),
-		},
-	})
+	api, err := client.NewFromConfig(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("creating api client: %w", err)
 	}
 
 	// Get proof set state
-	psState, err := api.GetProofSetState(ctx, appCfg.UCANService.ProofSetID)
+	psState, err := api.GetProofSetState(ctx, cfg.UCAN.ProofSetID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get proof set state: %w", err)
 	}


### PR DESCRIPTION
Fixes this: 
```
 sudo piri --config=/etc/piri/config.toml update
Current version: v0.1.0-c2d5d9f
Latest version: v0.1.1
Warning: Cannot determine if safe to update: loading config: config validation errors:
  - pdp.contracts.verifier is required but not provided (sources: flag)
  - pdp.contracts.provider_registry is required but not provided (sources: flag)
  - pdp.contracts.service is required but not provided (sources: flag)
  - pdp.contracts.service_view is required but not provided (sources: flag)
  - pdp.chain_id is required but not provided (sources: flag)
  - pdp.payer_address is required but not provided (sources: flag)
  - ucan.services.indexer.did is required but not provided (sources: flag)
  - ucan.services.indexer.url is required but not provided (sources: flag)
  - ucan.services.upload.did is required but not provided (sources: flag)
  - ucan.services.upload.url is required but not provided (sources: flag)
  - ucan.services.publisher.ipni_announce_urls must have at least 1 items (got 0; sources: flag)
Use --force to update anyway
Error: cannot determine node status

```