### PR TITLE
feat: enable tracing by default

### DIFF
--- a/docs/content/operations/telemetry.md
+++ b/docs/content/operations/telemetry.md
@@ -39,6 +39,10 @@ Piri collects information about your node, including pseudonymous identifiers th
 - **Upload Service DID**: The DID of the upload service you're connected to
 - **Upload Service URL**: The URL of the upload service (public endpoint)
 
+### Tracing data
+
+Tracing data is a specialized form of telemetry that provides an end-to-end view of a request's journey as it flows through the various components of a complex, distributed system, such as a microservices architecture.
+
 ## What Data Is NOT Collected
 
 We do NOT collect:
@@ -56,6 +60,12 @@ export PIRI_DISABLE_ANALYTICS=1
 ```
 
 To make this permanent, add the export to your shell configuration file (e.g., `.bashrc`, `.zshrc`).
+
+Note: you can opt-out of tracing _only_ by setting the `PIRI_TRACING_ENABLED` environment variable:
+
+```bash
+export PIRI_TRACING_ENABLED=0
+```
 
 ## Data Retention and Usage
 

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -33,9 +33,9 @@ func New(ctx context.Context, cfg Config) (*Telemetry, error) {
 		cfg.PublishInterval = defaultPublishInterval
 	}
 
-	// tracing is off by default, only enable if set
+	// tracing is on by default, but will only sample if parent is sampled
 	if cfg.TracesEndpoint == "" {
-		if os.Getenv("PIRI_TRACING_ENABLED") != "" {
+		if os.Getenv("PIRI_TRACING_ENABLED") != "0" {
 			cfg.TracesEndpoint = cfg.endpoint
 		}
 	}


### PR DESCRIPTION
Switches to enabling tracing by default, _unless_ `PIRI_TRACING_ENABLED` is set to `0`.

Note that tracing is configured such that it is only collected when the parent request is being collected.