### PR TITLE
feat: implement dynamic config for manager

### DIFF
--- a/cmd/cli/client/admin/config/get.go
+++ b/cmd/cli/client/admin/config/get.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var getCmd = &cobra.Command{
+	Use:   "get <key>",
+	Short: "Get a dynamic configuration value",
+	Args:  cobra.ExactArgs(1),
+	RunE:  doGet,
+}
+
+func init() {
+	Cmd.AddCommand(getCmd)
+}
+
+func doGet(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	key := args[0]
+
+	api, err := loadClient()
+	if err != nil {
+		return err
+	}
+
+	cfg, err := api.GetConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("getting config: %w", err)
+	}
+
+	value, ok := cfg.Values[key]
+	if !ok {
+		return fmt.Errorf("key %q not found in config", key)
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), value)
+	return nil
+}

--- a/cmd/cli/client/admin/config/list.go
+++ b/cmd/cli/client/admin/config/list.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all dynamic configuration values",
+	Args:  cobra.NoArgs,
+	RunE:  doList,
+}
+
+func init() {
+	Cmd.AddCommand(listCmd)
+}
+
+func doList(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+
+	api, err := loadClient()
+	if err != nil {
+		return err
+	}
+
+	cfg, err := api.GetConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("getting config: %w", err)
+	}
+
+	data, err := json.MarshalIndent(cfg.Values, "", "  ")
+	if err != nil {
+		return fmt.Errorf("rendering config: %w", err)
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), string(data))
+	return nil
+}

--- a/cmd/cli/client/admin/config/reload.go
+++ b/cmd/cli/client/admin/config/reload.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var reloadCmd = &cobra.Command{
+	Use:   "reload",
+	Short: "Reload configuration from file",
+	Long: `Triggers the server to re-read the config file and apply any changes.
+
+This is useful when you've manually edited the config file and want to apply
+the changes without restarting the server.
+
+Note: This only reloads values that are set in the config file. Values that
+were set via the API but not persisted will remain unchanged.`,
+	Args: cobra.NoArgs,
+	RunE: doReload,
+}
+
+func init() {
+	Cmd.AddCommand(reloadCmd)
+}
+
+func doReload(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+
+	api, err := loadClient()
+	if err != nil {
+		return err
+	}
+
+	cfg, err := api.ReloadConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("reloading config: %w", err)
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), "Configuration reloaded from file")
+
+	// Print reloaded values
+	data, err := json.MarshalIndent(cfg.Values, "", "  ")
+	if err != nil {
+		return fmt.Errorf("rendering config: %w", err)
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), string(data))
+
+	return nil
+}

--- a/cmd/cli/client/admin/config/root.go
+++ b/cmd/cli/client/admin/config/root.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/storacha/piri/pkg/admin/httpapi"
+	"github.com/storacha/piri/pkg/admin/httpapi/client"
+	"github.com/storacha/piri/pkg/config"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "config",
+	Short: "Manage dynamic configuration",
+}
+
+var setCmd = &cobra.Command{
+	Use:   "set <key> <value>",
+	Short: "Set a dynamic configuration value",
+	Long: `Set a dynamic configuration value.
+Examples:
+  piri client admin config set pdp.aggregation.manager.poll_interval 1m`,
+	Args: cobra.ExactArgs(2),
+	RunE: doSet,
+}
+
+var persistFlag bool
+
+func init() {
+	setCmd.Flags().BoolVar(&persistFlag, "persist", false, "Persist the change to the config file")
+	Cmd.AddCommand(setCmd)
+}
+
+func doSet(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	key := args[0]
+	value := args[1]
+
+	api, err := loadClient()
+	if err != nil {
+		return err
+	}
+
+	// Pass the value as a string - the registry will handle parsing and validation
+	req := httpapi.UpdateConfigRequest{
+		Updates: map[string]any{
+			key: value,
+		},
+		Persist: persistFlag,
+	}
+
+	_, err = api.UpdateConfig(ctx, req)
+	if err != nil {
+		return fmt.Errorf("updating config: %w", err)
+	}
+
+	if persistFlag {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s updated and persisted\n", key)
+	} else {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s updated\n", key)
+	}
+	return nil
+}
+
+func loadClient() (*client.Client, error) {
+	cfg, err := config.Load[config.Client]()
+	if err != nil {
+		return nil, fmt.Errorf("loading config: %w", err)
+	}
+
+	api, err := client.NewFromConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("creating admin client: %w", err)
+	}
+	return api, nil
+}

--- a/cmd/cli/client/admin/root.go
+++ b/cmd/cli/client/admin/root.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/storacha/piri/cmd/cli/client/admin/config"
 	"github.com/storacha/piri/cmd/cli/client/admin/log"
 	"github.com/storacha/piri/cmd/cli/client/admin/payment"
 )
@@ -15,4 +16,5 @@ var Cmd = &cobra.Command{
 func init() {
 	Cmd.AddCommand(log.Cmd)
 	Cmd.AddCommand(payment.Cmd)
+	Cmd.AddCommand(config.Cmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/ncruces/go-sqlite3 v0.24.1
 	github.com/patrickmn/go-cache v2.1.0+incompatible
+	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/raulk/clock v1.1.0
 	github.com/samber/lo v1.39.0
 	github.com/schollz/progressbar/v3 v3.18.0
@@ -264,7 +265,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9 // indirect
 	github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c // indirect
 	github.com/pion/dtls/v3 v3.0.7 // indirect

--- a/pkg/admin/httpapi/handlers/config.go
+++ b/pkg/admin/httpapi/handlers/config.go
@@ -1,0 +1,92 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/storacha/piri/pkg/admin/httpapi"
+	"github.com/storacha/piri/pkg/config/dynamic"
+)
+
+// ConfigHandler handles dynamic configuration API requests.
+type ConfigHandler struct {
+	registry *dynamic.Registry
+	bridge   *dynamic.ViperBridge
+}
+
+// NewConfigHandler creates a new ConfigHandler.
+func NewConfigHandler(registry *dynamic.Registry, bridge *dynamic.ViperBridge) *ConfigHandler {
+	return &ConfigHandler{
+		registry: registry,
+		bridge:   bridge,
+	}
+}
+
+// GetConfig returns the current dynamic configuration values.
+// GET /admin/config
+func (h *ConfigHandler) GetConfig(c echo.Context) error {
+	return c.JSON(http.StatusOK, httpapi.ConfigResponse{
+		Values: h.registry.GetAll(),
+	})
+}
+
+// UpdateConfig updates one or more dynamic configuration values.
+// PATCH /admin/config
+func (h *ConfigHandler) UpdateConfig(c echo.Context) error {
+	var req httpapi.UpdateConfigRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest,
+			fmt.Sprintf("invalid request body: %s", err))
+	}
+
+	if len(req.Updates) == 0 {
+		return echo.NewHTTPError(http.StatusBadRequest, "no updates provided")
+	}
+
+	// Registry handles ALL validation (parsing, type checking, constraints)
+	if err := h.registry.Update(req.Updates, req.Persist, dynamic.SourceAPI); err != nil {
+		return h.mapError(err)
+	}
+
+	return c.JSON(http.StatusOK, httpapi.ConfigResponse{
+		Values: h.registry.GetAll(),
+	})
+}
+
+// ReloadConfig reloads the configuration from the config file.
+// POST /admin/config/reload
+func (h *ConfigHandler) ReloadConfig(c echo.Context) error {
+	if h.bridge == nil {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "config reload not available (no config file)")
+	}
+
+	if err := h.bridge.Reload(); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError,
+			fmt.Sprintf("failed to reload config: %s", err))
+	}
+
+	return c.JSON(http.StatusOK, httpapi.ConfigResponse{
+		Values: h.registry.GetAll(),
+	})
+}
+
+// mapError maps dynamic config errors to appropriate HTTP errors.
+func (h *ConfigHandler) mapError(err error) *echo.HTTPError {
+	var validationErr *dynamic.ValidationError
+	var unknownKeyErr *dynamic.UnknownKeyError
+	var persistErr *dynamic.PersistError
+
+	switch {
+	case errors.As(err, &validationErr):
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	case errors.As(err, &unknownKeyErr):
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	case errors.As(err, &persistErr):
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	default:
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+}

--- a/pkg/admin/httpapi/routes.go
+++ b/pkg/admin/httpapi/routes.go
@@ -2,7 +2,9 @@ package httpapi
 
 const (
 	// Route path segments used by both server handlers and HTTP clients.
-	AdminRoutePath   = "/admin"
-	LogRoutePath     = "/log"
-	PaymentRoutePath = "/payment"
+	AdminRoutePath        = "/admin"
+	LogRoutePath          = "/log"
+	PaymentRoutePath      = "/payment"
+	ConfigRoutePath       = "/config"
+	ConfigReloadRoutePath = "/reload"
 )

--- a/pkg/admin/httpapi/types.go
+++ b/pkg/admin/httpapi/types.go
@@ -116,3 +116,21 @@ type (
 		ConfirmedBlock string `json:"confirmed_block,omitempty"`
 	}
 )
+
+// Dynamic Configuration
+type (
+	// ConfigResponse returns all dynamic configuration values as key-value pairs.
+	ConfigResponse struct {
+		Values map[string]any `json:"values"`
+	}
+
+	// UpdateConfigRequest updates one or more configuration values.
+	// Keys are dot-notation paths like "pdp.aggregation.manager.poll_interval".
+	// Values are raw JSON values that will be parsed and validated by the registry.
+	UpdateConfigRequest struct {
+		// Updates maps config key paths to their new values.
+		Updates map[string]any `json:"updates"`
+		// Persist writes changes to config file if true.
+		Persist bool `json:"persist"`
+	}
+)

--- a/pkg/config/app/pdp.go
+++ b/pkg/config/app/pdp.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"math/big"
 	"net/url"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/storacha/go-ucanto/client"
@@ -31,6 +32,8 @@ type PDPServiceConfig struct {
 	ChainID *big.Int
 	// PayerAddress is the Storacha Owned address that pays SPs
 	PayerAddress common.Address
+	// Aggregation contains aggregation manager configuration
+	Aggregation AggregationConfig
 }
 
 // SigningServiceConfig configures the signing service for PDP operations
@@ -40,4 +43,35 @@ type SigningServiceConfig struct {
 	// Private key for in-process signing (if using local signer)
 	// NB: this should only be used for development purposes
 	PrivateKey *ecdsa.PrivateKey
+}
+
+// AggregationConfig configures the PDP aggregation system.
+type AggregationConfig struct {
+	CommP      CommpConfig
+	Aggregator AggregatorConfig
+	Manager    AggregateManagerConfig
+}
+
+type CommpConfig struct {
+	JobQueue JobQueueConfig
+}
+
+type AggregatorConfig struct {
+	JobQueue JobQueueConfig
+}
+
+type AggregateManagerConfig struct {
+	// PollInterval is how often the aggregation manager flushes its buffer.
+	PollInterval time.Duration
+	// MaxBatchSize is the maximum number of aggregates per batch submission.
+	BatchSize uint
+	JobQueue  JobQueueConfig
+}
+type JobQueueConfig struct {
+	// The number of jobs the queue can process in parallel.
+	Workers uint
+	// The number of times a job can be retried before being considered failed.
+	Retries uint
+	// The duration between successive retries
+	RetryDelay time.Duration
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,6 +14,9 @@ type Normalizable interface {
 
 func Load[T Validatable]() (T, error) {
 	var out T
+
+	SetDefaults()
+
 	if err := viper.Unmarshal(&out); err != nil {
 		return out, err
 	}

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -1,4 +1,61 @@
 package config
 
+import (
+	"runtime"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
 // DefaultMinimumEgressBatchSize is the minimum allowed egress tracker batch size (10 MiB).
 const DefaultMinimumEgressBatchSize int64 = 10 * 1024 * 1024
+
+// Key is a configuration key path used with Viper.
+type Key string
+
+// PDP Aggregation - CommP
+const (
+	CommPJobQueueWorkers    Key = "pdp.aggregation.commp.job_queue.workers"
+	CommPJobQueueRetries    Key = "pdp.aggregation.commp.job_queue.retries"
+	CommPJobQueueRetryDelay Key = "pdp.aggregation.commp.job_queue.retry_delay"
+)
+
+// PDP Aggregation - Aggregator
+const (
+	AggregatorJobQueueWorkers    Key = "pdp.aggregation.aggregator.job_queue.workers"
+	AggregatorJobQueueRetries    Key = "pdp.aggregation.aggregator.job_queue.retries"
+	AggregatorJobQueueRetryDelay Key = "pdp.aggregation.aggregator.job_queue.retry_delay"
+)
+
+// PDP Aggregation - Manager (these are dynamic - can change at runtime)
+const (
+	ManagerPollInterval       Key = "pdp.aggregation.manager.poll_interval"
+	ManagerBatchSize          Key = "pdp.aggregation.manager.batch_size"
+	ManagerJobQueueWorkers    Key = "pdp.aggregation.manager.job_queue.workers"
+	ManagerJobQueueRetries    Key = "pdp.aggregation.manager.job_queue.retries"
+	ManagerJobQueueRetryDelay Key = "pdp.aggregation.manager.job_queue.retry_delay"
+)
+
+var defaultValues = map[Key]any{
+	CommPJobQueueWorkers:    runtime.NumCPU(),
+	CommPJobQueueRetries:    50,
+	CommPJobQueueRetryDelay: 10 * time.Second,
+
+	AggregatorJobQueueWorkers:    runtime.NumCPU(),
+	AggregatorJobQueueRetries:    50,
+	AggregatorJobQueueRetryDelay: 10 * time.Second,
+
+	ManagerPollInterval:       30 * time.Second,
+	ManagerBatchSize:          10,
+	ManagerJobQueueWorkers:    3,
+	ManagerJobQueueRetries:    50,
+	ManagerJobQueueRetryDelay: time.Minute,
+}
+
+// SetDefaults sets all viper defaults for configuration.
+// Called before viper.Unmarshal() to ensure defaults are available.
+func SetDefaults() {
+	for k, v := range defaultValues {
+		viper.SetDefault(string(k), v)
+	}
+}

--- a/pkg/config/dynamic/errors.go
+++ b/pkg/config/dynamic/errors.go
@@ -1,0 +1,76 @@
+package dynamic
+
+import (
+	"fmt"
+
+	"github.com/storacha/piri/pkg/config"
+)
+
+// ParseError indicates a value could not be parsed to the expected type.
+type ParseError struct {
+	Value    any
+	Expected string
+	Cause    error
+}
+
+func (e *ParseError) Error() string {
+	if e.Cause != nil {
+		return fmt.Sprintf("cannot parse %v: expected %s: %v", e.Value, e.Expected, e.Cause)
+	}
+	return fmt.Sprintf("cannot parse %v: expected %s", e.Value, e.Expected)
+}
+
+func (e *ParseError) Unwrap() error { return e.Cause }
+
+// TypeError indicates a type mismatch between expected and actual value.
+type TypeError struct {
+	Expected string
+	Got      string
+}
+
+func (e *TypeError) Error() string {
+	return fmt.Sprintf("type mismatch: expected %s, got %s", e.Expected, e.Got)
+}
+
+// RangeError indicates a value is outside the allowed range.
+type RangeError[T any] struct {
+	Value T
+	Min   T
+	Max   T
+}
+
+func (e *RangeError[T]) Error() string {
+	return fmt.Sprintf("value %v outside valid range [%v, %v]", e.Value, e.Min, e.Max)
+}
+
+// UnknownKeyError indicates an unrecognized configuration key.
+type UnknownKeyError struct {
+	Key string
+}
+
+func (e *UnknownKeyError) Error() string {
+	return fmt.Sprintf("unknown configuration key: %s", e.Key)
+}
+
+// ValidationError wraps a validation failure with the config key context.
+type ValidationError struct {
+	Key   config.Key
+	Cause error
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("invalid value for '%s': %v", e.Key, e.Cause)
+}
+
+func (e *ValidationError) Unwrap() error { return e.Cause }
+
+// PersistError indicates a failure to persist configuration to file.
+type PersistError struct {
+	Cause error
+}
+
+func (e *PersistError) Error() string {
+	return fmt.Sprintf("failed to persist configuration: %v", e.Cause)
+}
+
+func (e *PersistError) Unwrap() error { return e.Cause }

--- a/pkg/config/dynamic/fxmodule.go
+++ b/pkg/config/dynamic/fxmodule.go
@@ -1,0 +1,34 @@
+package dynamic
+
+import (
+	"github.com/spf13/viper"
+	"go.uber.org/fx"
+)
+
+// Module provides the dynamic configuration registry and viper bridge.
+// Packages register their own config entries via Registry.RegisterEntries.
+var Module = fx.Module("config/dynamic",
+	fx.Provide(
+		ProvideRegistry,
+		ProvideViperBridge,
+	),
+)
+
+// ProvideRegistry creates an empty Registry.
+// Packages register their own entries via RegisterEntries during fx startup.
+func ProvideRegistry() *Registry {
+	v := viper.GetViper()
+
+	// Create persister using surgical TOML updates (only if config file is used)
+	var persister Persister
+	if configFile := v.ConfigFileUsed(); configFile != "" {
+		persister = NewTOMLPersister(configFile)
+	}
+
+	return NewRegistry(nil, WithPersister(persister))
+}
+
+// ProvideViperBridge creates a ViperBridge for config file reloads.
+func ProvideViperBridge(registry *Registry) *ViperBridge {
+	return NewViperBridge(viper.GetViper(), registry)
+}

--- a/pkg/config/dynamic/registry.go
+++ b/pkg/config/dynamic/registry.go
@@ -1,0 +1,298 @@
+package dynamic
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	logging "github.com/ipfs/go-log/v2"
+
+	"github.com/storacha/piri/pkg/config"
+)
+
+var log = logging.Logger("config/dynamic")
+
+// Registry is the central store for all dynamic configuration values.
+// It provides thread-safe access to configuration and notifies observers of changes.
+type Registry struct {
+	mu             sync.RWMutex
+	config         map[config.Key]ConfigEntry
+	observers      map[config.Key][]observerEntry
+	nextObserverID uint64
+
+	// persister handles writing config changes to disk
+	persister Persister
+}
+
+// Persister handles persisting configuration changes.
+type Persister interface {
+	// Persist writes only the specified config changes to persistent storage.
+	// This enables surgical updates that preserve existing config file content.
+	Persist(updates map[config.Key]any) error
+}
+
+// ConfigEntry holds a configuration value and its schema for validation.
+type ConfigEntry struct {
+	Value  any
+	Schema ConfigSchema
+}
+
+// RegistryOption configures a Registry.
+type RegistryOption func(*Registry)
+
+// WithPersister sets the persister for writing config changes to disk.
+func WithPersister(p Persister) RegistryOption {
+	return func(r *Registry) {
+		r.persister = p
+	}
+}
+
+// NewRegistry creates a new Registry with the given configuration entries.
+// If cfgs is nil, an empty registry is created that can be populated via RegisterEntries.
+func NewRegistry(cfgs map[config.Key]ConfigEntry, opts ...RegistryOption) *Registry {
+	if cfgs == nil {
+		cfgs = make(map[config.Key]ConfigEntry)
+	}
+	r := &Registry{
+		config:    cfgs,
+		observers: make(map[config.Key][]observerEntry),
+	}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	return r
+}
+
+// Update accepts raw string keys and untyped values from the API.
+// It handles all parsing and validation internally.
+// If persist is true, the changes are written to persistent storage.
+// Returns an error if validation fails for any value.
+func (r *Registry) Update(updates map[string]any, persist bool, source ChangeSource) error {
+	if len(updates) == 0 {
+		return nil
+	}
+
+	r.mu.Lock()
+
+	// Phase 1: Parse and validate ALL updates before applying ANY
+	parsedUpdates := make(map[config.Key]any)
+
+	for keyStr, rawValue := range updates {
+		key := config.Key(keyStr)
+
+		entry, exists := r.config[key]
+		if !exists {
+			r.mu.Unlock()
+			return &UnknownKeyError{Key: keyStr}
+		}
+
+		// Schema handles both parsing (string → typed) and validation
+		typedValue, err := entry.Schema.ParseAndValidate(rawValue)
+		if err != nil {
+			r.mu.Unlock()
+			return &ValidationError{Key: key, Cause: err}
+		}
+
+		parsedUpdates[key] = typedValue
+	}
+
+	// Phase 2: Capture old values for rollback and notifications
+	oldValues := make(map[config.Key]any)
+	for key := range parsedUpdates {
+		oldValues[key] = r.config[key].Value
+	}
+
+	// Phase 3: Apply updates
+	for key, typedValue := range parsedUpdates {
+		entry := r.config[key]
+		entry.Value = typedValue
+		r.config[key] = entry
+	}
+
+	// Copy observers while holding the lock
+	observersCopy := make(map[config.Key][]observerEntry)
+	for key := range parsedUpdates {
+		if entries, ok := r.observers[key]; ok {
+			observersCopy[key] = append([]observerEntry{}, entries...)
+		}
+	}
+
+	r.mu.Unlock()
+
+	// Phase 4: Persist if requested
+	if persist && r.persister != nil {
+		if err := r.persister.Persist(parsedUpdates); err != nil {
+			// Rollback in-memory changes
+			r.mu.Lock()
+			for key, oldValue := range oldValues {
+				entry := r.config[key]
+				entry.Value = oldValue
+				r.config[key] = entry
+			}
+			r.mu.Unlock()
+			return &PersistError{Cause: err}
+		}
+	}
+
+	// Phase 5: Notify observers outside of lock
+	for key, typedValue := range parsedUpdates {
+		event := ChangeEvent{
+			Key:      key,
+			OldValue: oldValues[key],
+			NewValue: typedValue,
+			Source:   source,
+		}
+
+		log.Infow("Config value changed",
+			"key", event.Key,
+			"old_value", event.OldValue,
+			"new_value", event.NewValue,
+			"source", event.Source,
+		)
+
+		for _, entry := range observersCopy[key] {
+			entry.observer.OnConfigChange(event)
+		}
+	}
+
+	return nil
+}
+
+// GetDuration returns the duration value for the given key.
+// If the key doesn't exist or the value is not a duration, returns the fallback.
+func (r *Registry) GetDuration(key config.Key, fallback time.Duration) time.Duration {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if entry, ok := r.config[key]; ok {
+		if d, ok := entry.Value.(time.Duration); ok {
+			return d
+		}
+	}
+	return fallback
+}
+
+// GetInt returns the int value for the given key.
+// If the key doesn't exist or the value is not an int, returns the fallback.
+func (r *Registry) GetInt(key config.Key, fallback int) int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if entry, ok := r.config[key]; ok {
+		if i, ok := entry.Value.(int); ok {
+			return i
+		}
+	}
+	return fallback
+}
+
+// GetUint returns the uint value for the given key.
+// If the key doesn't exist or the value is not a uint, returns the fallback.
+func (r *Registry) GetUint(key config.Key, fallback uint) uint {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if entry, ok := r.config[key]; ok {
+		if u, ok := entry.Value.(uint); ok {
+			return u
+		}
+	}
+	return fallback
+}
+
+// GetAll returns all config values as a map (for API response).
+// Duration values are formatted as strings.
+func (r *Registry) GetAll() map[string]any {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make(map[string]any)
+	for key, entry := range r.config {
+		// Format values for JSON response
+		switch v := entry.Value.(type) {
+		case time.Duration:
+			result[string(key)] = v.String()
+		default:
+			result[string(key)] = v
+		}
+	}
+	return result
+}
+
+// Keys returns all registered configuration keys.
+func (r *Registry) Keys() []config.Key {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	keys := make([]config.Key, 0, len(r.config))
+	for key := range r.config {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+// RegisterEntries adds new configuration entries to the registry.
+// This allows packages to register their own dynamic config keys.
+// Returns an error if any key is already registered.
+func (r *Registry) RegisterEntries(entries map[config.Key]ConfigEntry) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Check for conflicts first
+	for key := range entries {
+		if _, exists := r.config[key]; exists {
+			return fmt.Errorf("config key %s already registered", key)
+		}
+	}
+
+	// Add all entries
+	for key, entry := range entries {
+		r.config[key] = entry
+	}
+
+	return nil
+}
+
+// observerEntry wraps an observer with an ID for unsubscription.
+type observerEntry struct {
+	id       uint64
+	observer Observer
+}
+
+// Subscribe registers an observer for changes to the specified key.
+// Returns a function to unsubscribe the observer.
+func (r *Registry) Subscribe(key config.Key, observer Observer) (func(), error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, has := r.config[key]; !has {
+		return nil, fmt.Errorf("key %s does not exist", key)
+	}
+
+	// Generate a unique ID for this subscription
+	id := r.nextObserverID
+	r.nextObserverID++
+
+	entry := observerEntry{id: id, observer: observer}
+	r.observers[key] = append(r.observers[key], entry)
+
+	return func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+
+		entries := r.observers[key]
+		for i, e := range entries {
+			if e.id == id {
+				r.observers[key] = append(entries[:i], entries[i+1:]...)
+				break
+			}
+		}
+	}, nil
+}
+
+// SubscribeFunc is a convenience method that wraps a function as an Observer.
+func (r *Registry) SubscribeFunc(key config.Key, fn func(ChangeEvent)) (func(), error) {
+	return r.Subscribe(key, ObserverFunc(fn))
+}

--- a/pkg/config/dynamic/registry_test.go
+++ b/pkg/config/dynamic/registry_test.go
@@ -1,0 +1,479 @@
+package dynamic
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/storacha/piri/pkg/config"
+)
+
+// Test keys for registry tests
+const (
+	testKeyDuration config.Key = "test.duration"
+	testKeyInt      config.Key = "test.int"
+	testKeyUint     config.Key = "test.uint"
+)
+
+// mockPersister for testing persist/rollback behavior
+type mockPersister struct {
+	mu    sync.Mutex
+	err   error
+	calls []map[config.Key]any
+}
+
+func (m *mockPersister) Persist(updates map[config.Key]any) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, updates)
+	return m.err
+}
+
+func TestNewRegistry(t *testing.T) {
+	t.Run("creates registry with nil map", func(t *testing.T) {
+		r := NewRegistry(nil)
+		require.NotNil(t, r)
+		require.Empty(t, r.Keys())
+	})
+
+	t.Run("creates registry with initial entries", func(t *testing.T) {
+		entries := map[config.Key]ConfigEntry{
+			testKeyDuration: {
+				Value:  30 * time.Second,
+				Schema: DurationSchema{Min: time.Second, Max: time.Hour},
+			},
+		}
+		r := NewRegistry(entries)
+		require.Len(t, r.Keys(), 1)
+		require.Equal(t, 30*time.Second, r.GetDuration(testKeyDuration, 0))
+	})
+
+	t.Run("applies WithPersister option", func(t *testing.T) {
+		p := &mockPersister{}
+		r := NewRegistry(nil, WithPersister(p))
+		require.NotNil(t, r.persister)
+	})
+}
+
+func TestRegistry_RegisterEntries(t *testing.T) {
+	t.Run("successfully registers new entries", func(t *testing.T) {
+		r := NewRegistry(nil)
+		err := r.RegisterEntries(map[config.Key]ConfigEntry{
+			testKeyDuration: {
+				Value:  30 * time.Second,
+				Schema: DurationSchema{Min: time.Second, Max: time.Hour},
+			},
+			testKeyUint: {
+				Value:  uint(10),
+				Schema: UintSchema{Min: 1, Max: 100},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, r.Keys(), 2)
+	})
+
+	t.Run("returns error on duplicate key", func(t *testing.T) {
+		r := NewRegistry(map[config.Key]ConfigEntry{
+			testKeyDuration: {
+				Value:  30 * time.Second,
+				Schema: DurationSchema{Min: time.Second, Max: time.Hour},
+			},
+		})
+
+		err := r.RegisterEntries(map[config.Key]ConfigEntry{
+			testKeyDuration: {
+				Value:  60 * time.Second,
+				Schema: DurationSchema{Min: time.Second, Max: time.Hour},
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "already registered")
+
+		// Original value should be unchanged
+		require.Equal(t, 30*time.Second, r.GetDuration(testKeyDuration, 0))
+	})
+}
+
+func TestRegistry_Update(t *testing.T) {
+	t.Run("successfully updates existing key", func(t *testing.T) {
+		r := NewRegistry(map[config.Key]ConfigEntry{
+			testKeyDuration: {
+				Value:  30 * time.Second,
+				Schema: DurationSchema{Min: time.Second, Max: time.Hour},
+			},
+		})
+
+		err := r.Update(map[string]any{
+			string(testKeyDuration): "1m",
+		}, false, SourceAPI)
+		require.NoError(t, err)
+		require.Equal(t, time.Minute, r.GetDuration(testKeyDuration, 0))
+	})
+
+	t.Run("returns UnknownKeyError for unknown key", func(t *testing.T) {
+		r := NewRegistry(nil)
+		err := r.Update(map[string]any{
+			"unknown.key": "value",
+		}, false, SourceAPI)
+		require.Error(t, err)
+
+		var unknownKeyErr *UnknownKeyError
+		require.True(t, errors.As(err, &unknownKeyErr))
+		require.Equal(t, "unknown.key", unknownKeyErr.Key)
+	})
+
+	t.Run("returns ValidationError when schema validation fails", func(t *testing.T) {
+		r := NewRegistry(map[config.Key]ConfigEntry{
+			testKeyDuration: {
+				Value:  30 * time.Second,
+				Schema: DurationSchema{Min: time.Minute, Max: time.Hour},
+			},
+		})
+
+		err := r.Update(map[string]any{
+			string(testKeyDuration): "1s", // Below min of 1 minute
+		}, false, SourceAPI)
+		require.Error(t, err)
+
+		var validationErr *ValidationError
+		require.True(t, errors.As(err, &validationErr))
+		require.Equal(t, testKeyDuration, validationErr.Key)
+	})
+
+	t.Run("notifies subscribers on change", func(t *testing.T) {
+		r := NewRegistry(map[config.Key]ConfigEntry{
+			testKeyDuration: {
+				Value:  30 * time.Second,
+				Schema: DurationSchema{Min: time.Second, Max: time.Hour},
+			},
+		})
+
+		var received ChangeEvent
+		_, err := r.SubscribeFunc(testKeyDuration, func(e ChangeEvent) {
+			received = e
+		})
+		require.NoError(t, err)
+
+		err = r.Update(map[string]any{
+			string(testKeyDuration): "1m",
+		}, false, SourceAPI)
+		require.NoError(t, err)
+
+		require.Equal(t, testKeyDuration, received.Key)
+		require.Equal(t, 30*time.Second, received.OldValue)
+		require.Equal(t, time.Minute, received.NewValue)
+		require.Equal(t, SourceAPI, received.Source)
+	})
+
+	t.Run("persists to file when persist=true", func(t *testing.T) {
+		p := &mockPersister{}
+		r := NewRegistry(map[config.Key]ConfigEntry{
+			testKeyDuration: {
+				Value:  30 * time.Second,
+				Schema: DurationSchema{Min: time.Second, Max: time.Hour},
+			},
+		}, WithPersister(p))
+
+		err := r.Update(map[string]any{
+			string(testKeyDuration): "1m",
+		}, true, SourceAPI)
+		require.NoError(t, err)
+
+		require.Len(t, p.calls, 1)
+		require.Equal(t, time.Minute, p.calls[0][testKeyDuration])
+	})
+
+	t.Run("does not persist when persist=false", func(t *testing.T) {
+		p := &mockPersister{}
+		r := NewRegistry(map[config.Key]ConfigEntry{
+			testKeyDuration: {
+				Value:  30 * time.Second,
+				Schema: DurationSchema{Min: time.Second, Max: time.Hour},
+			},
+		}, WithPersister(p))
+
+		err := r.Update(map[string]any{
+			string(testKeyDuration): "1m",
+		}, false, SourceAPI)
+		require.NoError(t, err)
+		require.Empty(t, p.calls)
+	})
+
+	t.Run("rolls back in-memory changes when persist fails", func(t *testing.T) {
+		p := &mockPersister{err: errors.New("disk full")}
+		r := NewRegistry(map[config.Key]ConfigEntry{
+			testKeyDuration: {
+				Value:  30 * time.Second,
+				Schema: DurationSchema{Min: time.Second, Max: time.Hour},
+			},
+		}, WithPersister(p))
+
+		err := r.Update(map[string]any{
+			string(testKeyDuration): "1m",
+		}, true, SourceAPI)
+		require.Error(t, err)
+
+		var persistErr *PersistError
+		require.True(t, errors.As(err, &persistErr))
+
+		// Value should be rolled back to original
+		require.Equal(t, 30*time.Second, r.GetDuration(testKeyDuration, 0))
+	})
+
+	t.Run("empty updates map is no-op", func(t *testing.T) {
+		r := NewRegistry(nil)
+		err := r.Update(map[string]any{}, false, SourceAPI)
+		require.NoError(t, err)
+	})
+
+	t.Run("multiple observers all notified", func(t *testing.T) {
+		r := NewRegistry(map[config.Key]ConfigEntry{
+			testKeyDuration: {
+				Value:  30 * time.Second,
+				Schema: DurationSchema{Min: time.Second, Max: time.Hour},
+			},
+		})
+
+		var count atomic.Int32
+		for i := 0; i < 3; i++ {
+			_, err := r.SubscribeFunc(testKeyDuration, func(e ChangeEvent) {
+				count.Add(1)
+			})
+			require.NoError(t, err)
+		}
+
+		err := r.Update(map[string]any{
+			string(testKeyDuration): "1m",
+		}, false, SourceAPI)
+		require.NoError(t, err)
+		require.Equal(t, int32(3), count.Load())
+	})
+}
+
+func TestRegistry_GetDuration(t *testing.T) {
+	r := NewRegistry(map[config.Key]ConfigEntry{
+		testKeyDuration: {
+			Value:  30 * time.Second,
+			Schema: DurationSchema{Min: time.Second, Max: time.Hour},
+		},
+		testKeyUint: {
+			Value:  uint(10),
+			Schema: UintSchema{Min: 1, Max: 100},
+		},
+	})
+
+	t.Run("returns value when key exists", func(t *testing.T) {
+		got := r.GetDuration(testKeyDuration, time.Hour)
+		require.Equal(t, 30*time.Second, got)
+	})
+
+	t.Run("returns fallback when key doesn't exist", func(t *testing.T) {
+		got := r.GetDuration("nonexistent", time.Hour)
+		require.Equal(t, time.Hour, got)
+	})
+
+	t.Run("returns fallback when value is wrong type", func(t *testing.T) {
+		got := r.GetDuration(testKeyUint, time.Hour)
+		require.Equal(t, time.Hour, got)
+	})
+}
+
+func TestRegistry_GetInt(t *testing.T) {
+	r := NewRegistry(map[config.Key]ConfigEntry{
+		testKeyInt: {
+			Value:  50,
+			Schema: IntSchema{Min: 0, Max: 100},
+		},
+		testKeyDuration: {
+			Value:  30 * time.Second,
+			Schema: DurationSchema{Min: time.Second, Max: time.Hour},
+		},
+	})
+
+	t.Run("returns value when key exists", func(t *testing.T) {
+		got := r.GetInt(testKeyInt, 0)
+		require.Equal(t, 50, got)
+	})
+
+	t.Run("returns fallback when key doesn't exist", func(t *testing.T) {
+		got := r.GetInt("nonexistent", 99)
+		require.Equal(t, 99, got)
+	})
+
+	t.Run("returns fallback when value is wrong type", func(t *testing.T) {
+		got := r.GetInt(testKeyDuration, 99)
+		require.Equal(t, 99, got)
+	})
+}
+
+func TestRegistry_GetUint(t *testing.T) {
+	r := NewRegistry(map[config.Key]ConfigEntry{
+		testKeyUint: {
+			Value:  uint(50),
+			Schema: UintSchema{Min: 0, Max: 100},
+		},
+		testKeyDuration: {
+			Value:  30 * time.Second,
+			Schema: DurationSchema{Min: time.Second, Max: time.Hour},
+		},
+	})
+
+	t.Run("returns value when key exists", func(t *testing.T) {
+		got := r.GetUint(testKeyUint, 0)
+		require.Equal(t, uint(50), got)
+	})
+
+	t.Run("returns fallback when key doesn't exist", func(t *testing.T) {
+		got := r.GetUint("nonexistent", 99)
+		require.Equal(t, uint(99), got)
+	})
+
+	t.Run("returns fallback when value is wrong type", func(t *testing.T) {
+		got := r.GetUint(testKeyDuration, 99)
+		require.Equal(t, uint(99), got)
+	})
+}
+
+func TestRegistry_GetAll(t *testing.T) {
+	r := NewRegistry(map[config.Key]ConfigEntry{
+		testKeyDuration: {
+			Value:  30 * time.Second,
+			Schema: DurationSchema{Min: time.Second, Max: time.Hour},
+		},
+		testKeyUint: {
+			Value:  uint(50),
+			Schema: UintSchema{Min: 0, Max: 100},
+		},
+	})
+
+	all := r.GetAll()
+	require.Len(t, all, 2)
+	require.Equal(t, "30s", all[string(testKeyDuration)]) // Duration formatted as string
+	require.Equal(t, uint(50), all[string(testKeyUint)])
+}
+
+func TestRegistry_Keys(t *testing.T) {
+	r := NewRegistry(map[config.Key]ConfigEntry{
+		testKeyDuration: {Value: 30 * time.Second, Schema: DurationSchema{}},
+		testKeyUint:     {Value: uint(10), Schema: UintSchema{}},
+	})
+
+	keys := r.Keys()
+	require.Len(t, keys, 2)
+	require.Contains(t, keys, testKeyDuration)
+	require.Contains(t, keys, testKeyUint)
+}
+
+func TestRegistry_Subscribe(t *testing.T) {
+	t.Run("observer receives ChangeEvent on update", func(t *testing.T) {
+		r := NewRegistry(map[config.Key]ConfigEntry{
+			testKeyDuration: {
+				Value:  30 * time.Second,
+				Schema: DurationSchema{Min: time.Second, Max: time.Hour},
+			},
+		})
+
+		var received ChangeEvent
+		_, err := r.Subscribe(testKeyDuration, ObserverFunc(func(e ChangeEvent) {
+			received = e
+		}))
+		require.NoError(t, err)
+
+		err = r.Update(map[string]any{string(testKeyDuration): "1m"}, false, SourceFile)
+		require.NoError(t, err)
+
+		require.Equal(t, testKeyDuration, received.Key)
+		require.Equal(t, SourceFile, received.Source)
+	})
+
+	t.Run("unsubscribe function removes observer", func(t *testing.T) {
+		r := NewRegistry(map[config.Key]ConfigEntry{
+			testKeyDuration: {
+				Value:  30 * time.Second,
+				Schema: DurationSchema{Min: time.Second, Max: time.Hour},
+			},
+		})
+
+		var count atomic.Int32
+		unsubscribe, err := r.SubscribeFunc(testKeyDuration, func(e ChangeEvent) {
+			count.Add(1)
+		})
+		require.NoError(t, err)
+
+		// First update - should be received
+		err = r.Update(map[string]any{string(testKeyDuration): "1m"}, false, SourceAPI)
+		require.NoError(t, err)
+		require.Equal(t, int32(1), count.Load())
+
+		// Unsubscribe
+		unsubscribe()
+
+		// Second update - should NOT be received
+		err = r.Update(map[string]any{string(testKeyDuration): "2m"}, false, SourceAPI)
+		require.NoError(t, err)
+		require.Equal(t, int32(1), count.Load()) // Still 1
+	})
+
+	t.Run("returns error when subscribing to non-existent key", func(t *testing.T) {
+		r := NewRegistry(nil)
+		_, err := r.Subscribe("nonexistent", ObserverFunc(func(e ChangeEvent) {}))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "does not exist")
+	})
+}
+
+func TestRegistry_ConcurrentAccess(t *testing.T) {
+	r := NewRegistry(map[config.Key]ConfigEntry{
+		testKeyDuration: {
+			Value:  30 * time.Second,
+			Schema: DurationSchema{Min: time.Second, Max: time.Hour},
+		},
+		testKeyUint: {
+			Value:  uint(10),
+			Schema: UintSchema{Min: 1, Max: 100},
+		},
+	})
+
+	var wg sync.WaitGroup
+	iterations := 100
+
+	// Concurrent reads
+	for i := 0; i < iterations; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = r.GetDuration(testKeyDuration, 0)
+			_ = r.GetUint(testKeyUint, 0)
+			_ = r.Keys()
+			_ = r.GetAll()
+		}()
+	}
+
+	// Concurrent writes (with different valid values)
+	for i := 0; i < iterations; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			duration := time.Duration(i%60+1) * time.Second
+			_ = r.Update(map[string]any{string(testKeyDuration): duration.String()}, false, SourceAPI)
+		}(i)
+	}
+
+	// Concurrent subscribe/unsubscribe
+	for i := 0; i < iterations; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			unsub, err := r.SubscribeFunc(testKeyDuration, func(e ChangeEvent) {})
+			if err == nil {
+				unsub()
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/pkg/config/dynamic/schema.go
+++ b/pkg/config/dynamic/schema.go
@@ -1,0 +1,185 @@
+package dynamic
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// ConfigSchema handles parsing raw JSON values and validating them.
+type ConfigSchema interface {
+	// ParseAndValidate converts a raw value (from JSON) to a typed value
+	// and validates it against constraints.
+	// Returns the typed value or a descriptive error.
+	ParseAndValidate(raw any) (any, error)
+
+	// TypeDescription returns human-readable type info for error messages.
+	TypeDescription() string
+}
+
+// DurationSchema parses and validates duration values.
+// Accepts string values like "30s", "5m", "1h" or time.Duration directly.
+type DurationSchema struct {
+	Min time.Duration
+	Max time.Duration
+}
+
+func (s DurationSchema) TypeDescription() string {
+	return fmt.Sprintf("duration string (e.g., '30s', '5m'), range [%s, %s]", s.Min, s.Max)
+}
+
+func (s DurationSchema) ParseAndValidate(raw any) (any, error) {
+	var d time.Duration
+
+	switch v := raw.(type) {
+	case string:
+		parsed, err := time.ParseDuration(v)
+		if err != nil {
+			return nil, &ParseError{
+				Value:    v,
+				Expected: "duration string (e.g., '30s', '5m')",
+				Cause:    err,
+			}
+		}
+		d = parsed
+	case time.Duration:
+		// Already typed (e.g., from internal code path)
+		d = v
+	default:
+		return nil, &TypeError{
+			Expected: "duration string",
+			Got:      fmt.Sprintf("%T", raw),
+		}
+	}
+
+	if s.Min > 0 && d < s.Min {
+		return nil, &RangeError[time.Duration]{Value: d, Min: s.Min, Max: s.Max}
+	}
+	if s.Max > 0 && d > s.Max {
+		return nil, &RangeError[time.Duration]{Value: d, Min: s.Min, Max: s.Max}
+	}
+
+	return d, nil
+}
+
+// IntSchema parses and validates integer values.
+// Accepts int, int64, float64 (from JSON), or string representations.
+type IntSchema struct {
+	Min int
+	Max int
+}
+
+func (s IntSchema) TypeDescription() string {
+	return fmt.Sprintf("integer, range [%d, %d]", s.Min, s.Max)
+}
+
+func (s IntSchema) ParseAndValidate(raw any) (any, error) {
+	var i int
+
+	switch v := raw.(type) {
+	case int:
+		i = v
+	case int64:
+		i = int(v)
+	case float64:
+		// JSON unmarshals numbers as float64
+		if v != float64(int(v)) {
+			return nil, &ParseError{
+				Value:    v,
+				Expected: "integer (got floating point)",
+			}
+		}
+		i = int(v)
+	case string:
+		parsed, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, &ParseError{Value: v, Expected: "integer", Cause: err}
+		}
+		i = parsed
+	default:
+		return nil, &TypeError{
+			Expected: "integer",
+			Got:      fmt.Sprintf("%T", raw),
+		}
+	}
+
+	if i < s.Min {
+		return nil, &RangeError[int]{Value: i, Min: s.Min, Max: s.Max}
+	}
+	if i > s.Max {
+		return nil, &RangeError[int]{Value: i, Min: s.Min, Max: s.Max}
+	}
+
+	return i, nil
+}
+
+// UintSchema parses and validates unsigned integer values.
+// Accepts uint, int, int64, float64 (from JSON), or string representations.
+type UintSchema struct {
+	Min uint
+	Max uint
+}
+
+func (s UintSchema) TypeDescription() string {
+	return fmt.Sprintf("unsigned integer, range [%d, %d]", s.Min, s.Max)
+}
+
+func (s UintSchema) ParseAndValidate(raw any) (any, error) {
+	var u uint
+
+	switch v := raw.(type) {
+	case uint:
+		u = v
+	case int:
+		if v < 0 {
+			return nil, &ParseError{
+				Value:    v,
+				Expected: "unsigned integer (got negative value)",
+			}
+		}
+		u = uint(v)
+	case int64:
+		if v < 0 {
+			return nil, &ParseError{
+				Value:    v,
+				Expected: "unsigned integer (got negative value)",
+			}
+		}
+		u = uint(v)
+	case float64:
+		// JSON unmarshals numbers as float64
+		if v != float64(int(v)) {
+			return nil, &ParseError{
+				Value:    v,
+				Expected: "unsigned integer (got floating point)",
+			}
+		}
+		if v < 0 {
+			return nil, &ParseError{
+				Value:    v,
+				Expected: "unsigned integer (got negative value)",
+			}
+		}
+		u = uint(v)
+	case string:
+		parsed, err := strconv.ParseUint(v, 10, 64)
+		if err != nil {
+			return nil, &ParseError{Value: v, Expected: "unsigned integer", Cause: err}
+		}
+		u = uint(parsed)
+	default:
+		return nil, &TypeError{
+			Expected: "unsigned integer",
+			Got:      fmt.Sprintf("%T", raw),
+		}
+	}
+
+	if u < s.Min {
+		return nil, &RangeError[uint]{Value: u, Min: s.Min, Max: s.Max}
+	}
+	if u > s.Max {
+		return nil, &RangeError[uint]{Value: u, Min: s.Min, Max: s.Max}
+	}
+
+	return u, nil
+}

--- a/pkg/config/dynamic/schema_test.go
+++ b/pkg/config/dynamic/schema_test.go
@@ -1,0 +1,377 @@
+package dynamic
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDurationSchema_ParseAndValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		schema  DurationSchema
+		input   any
+		want    time.Duration
+		wantErr bool
+		errType any
+	}{
+		{
+			name:   "parses string 30s",
+			schema: DurationSchema{Min: time.Second, Max: time.Hour},
+			input:  "30s",
+			want:   30 * time.Second,
+		},
+		{
+			name:   "parses string 5m",
+			schema: DurationSchema{Min: time.Second, Max: time.Hour},
+			input:  "5m",
+			want:   5 * time.Minute,
+		},
+		{
+			name:   "parses string 1h",
+			schema: DurationSchema{Min: time.Second, Max: 2 * time.Hour},
+			input:  "1h",
+			want:   time.Hour,
+		},
+		{
+			name:   "accepts time.Duration directly",
+			schema: DurationSchema{Min: time.Second, Max: time.Hour},
+			input:  30 * time.Second,
+			want:   30 * time.Second,
+		},
+		{
+			name:    "rejects invalid string",
+			schema:  DurationSchema{Min: time.Second, Max: time.Hour},
+			input:   "invalid",
+			wantErr: true,
+			errType: &ParseError{},
+		},
+		{
+			name:    "rejects int type",
+			schema:  DurationSchema{Min: time.Second, Max: time.Hour},
+			input:   30,
+			wantErr: true,
+			errType: &TypeError{},
+		},
+		{
+			name:    "rejects bool type",
+			schema:  DurationSchema{Min: time.Second, Max: time.Hour},
+			input:   true,
+			wantErr: true,
+			errType: &TypeError{},
+		},
+		{
+			name:    "validates min constraint",
+			schema:  DurationSchema{Min: time.Minute, Max: time.Hour},
+			input:   "1s",
+			wantErr: true,
+			errType: &RangeError[time.Duration]{},
+		},
+		{
+			name:    "validates max constraint",
+			schema:  DurationSchema{Min: time.Second, Max: time.Minute},
+			input:   "2m",
+			wantErr: true,
+			errType: &RangeError[time.Duration]{},
+		},
+		{
+			name:   "accepts value at min boundary",
+			schema: DurationSchema{Min: time.Minute, Max: time.Hour},
+			input:  "1m",
+			want:   time.Minute,
+		},
+		{
+			name:   "accepts value at max boundary",
+			schema: DurationSchema{Min: time.Second, Max: time.Hour},
+			input:  "1h",
+			want:   time.Hour,
+		},
+		{
+			name:   "zero min allows any positive duration",
+			schema: DurationSchema{Min: 0, Max: time.Hour},
+			input:  "1ns",
+			want:   time.Nanosecond,
+		},
+		{
+			name:   "zero max allows any duration",
+			schema: DurationSchema{Min: time.Second, Max: 0},
+			input:  "1000h",
+			want:   1000 * time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.schema.ParseAndValidate(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errType != nil {
+					require.IsType(t, tt.errType, err)
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDurationSchema_TypeDescription(t *testing.T) {
+	schema := DurationSchema{Min: time.Second, Max: time.Hour}
+	desc := schema.TypeDescription()
+	require.Contains(t, desc, "duration")
+	require.Contains(t, desc, "1s")
+	require.Contains(t, desc, "1h0m0s")
+}
+
+func TestIntSchema_ParseAndValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		schema  IntSchema
+		input   any
+		want    int
+		wantErr bool
+		errType any
+	}{
+		{
+			name:   "parses int directly",
+			schema: IntSchema{Min: 0, Max: 100},
+			input:  50,
+			want:   50,
+		},
+		{
+			name:   "parses int64",
+			schema: IntSchema{Min: 0, Max: 100},
+			input:  int64(50),
+			want:   50,
+		},
+		{
+			name:   "parses float64 whole number",
+			schema: IntSchema{Min: 0, Max: 100},
+			input:  float64(50),
+			want:   50,
+		},
+		{
+			name:   "parses string",
+			schema: IntSchema{Min: 0, Max: 100},
+			input:  "50",
+			want:   50,
+		},
+		{
+			name:   "parses negative int",
+			schema: IntSchema{Min: -100, Max: 100},
+			input:  -50,
+			want:   -50,
+		},
+		{
+			name:    "rejects float64 with decimal",
+			schema:  IntSchema{Min: 0, Max: 100},
+			input:   50.5,
+			wantErr: true,
+			errType: &ParseError{},
+		},
+		{
+			name:    "rejects invalid string",
+			schema:  IntSchema{Min: 0, Max: 100},
+			input:   "not a number",
+			wantErr: true,
+			errType: &ParseError{},
+		},
+		{
+			name:    "rejects bool type",
+			schema:  IntSchema{Min: 0, Max: 100},
+			input:   true,
+			wantErr: true,
+			errType: &TypeError{},
+		},
+		{
+			name:    "validates min constraint",
+			schema:  IntSchema{Min: 10, Max: 100},
+			input:   5,
+			wantErr: true,
+			errType: &RangeError[int]{},
+		},
+		{
+			name:    "validates max constraint",
+			schema:  IntSchema{Min: 0, Max: 100},
+			input:   150,
+			wantErr: true,
+			errType: &RangeError[int]{},
+		},
+		{
+			name:   "accepts value at min boundary",
+			schema: IntSchema{Min: 10, Max: 100},
+			input:  10,
+			want:   10,
+		},
+		{
+			name:   "accepts value at max boundary",
+			schema: IntSchema{Min: 0, Max: 100},
+			input:  100,
+			want:   100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.schema.ParseAndValidate(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errType != nil {
+					require.IsType(t, tt.errType, err)
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIntSchema_TypeDescription(t *testing.T) {
+	schema := IntSchema{Min: 1, Max: 100}
+	desc := schema.TypeDescription()
+	require.Contains(t, desc, "integer")
+	require.Contains(t, desc, "1")
+	require.Contains(t, desc, "100")
+}
+
+func TestUintSchema_ParseAndValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		schema  UintSchema
+		input   any
+		want    uint
+		wantErr bool
+		errType any
+	}{
+		{
+			name:   "parses uint directly",
+			schema: UintSchema{Min: 0, Max: 100},
+			input:  uint(50),
+			want:   50,
+		},
+		{
+			name:   "parses positive int",
+			schema: UintSchema{Min: 0, Max: 100},
+			input:  50,
+			want:   50,
+		},
+		{
+			name:   "parses positive int64",
+			schema: UintSchema{Min: 0, Max: 100},
+			input:  int64(50),
+			want:   50,
+		},
+		{
+			name:   "parses positive float64 whole number",
+			schema: UintSchema{Min: 0, Max: 100},
+			input:  float64(50),
+			want:   50,
+		},
+		{
+			name:   "parses string",
+			schema: UintSchema{Min: 0, Max: 100},
+			input:  "50",
+			want:   50,
+		},
+		{
+			name:    "rejects negative int",
+			schema:  UintSchema{Min: 0, Max: 100},
+			input:   -5,
+			wantErr: true,
+			errType: &ParseError{},
+		},
+		{
+			name:    "rejects negative int64",
+			schema:  UintSchema{Min: 0, Max: 100},
+			input:   int64(-5),
+			wantErr: true,
+			errType: &ParseError{},
+		},
+		{
+			name:    "rejects negative float64",
+			schema:  UintSchema{Min: 0, Max: 100},
+			input:   float64(-5),
+			wantErr: true,
+			errType: &ParseError{},
+		},
+		{
+			name:    "rejects float64 with decimal",
+			schema:  UintSchema{Min: 0, Max: 100},
+			input:   50.5,
+			wantErr: true,
+			errType: &ParseError{},
+		},
+		{
+			name:    "rejects invalid string",
+			schema:  UintSchema{Min: 0, Max: 100},
+			input:   "not a number",
+			wantErr: true,
+			errType: &ParseError{},
+		},
+		{
+			name:    "rejects bool type",
+			schema:  UintSchema{Min: 0, Max: 100},
+			input:   true,
+			wantErr: true,
+			errType: &TypeError{},
+		},
+		{
+			name:    "validates min constraint",
+			schema:  UintSchema{Min: 10, Max: 100},
+			input:   uint(5),
+			wantErr: true,
+			errType: &RangeError[uint]{},
+		},
+		{
+			name:    "validates max constraint",
+			schema:  UintSchema{Min: 0, Max: 100},
+			input:   uint(150),
+			wantErr: true,
+			errType: &RangeError[uint]{},
+		},
+		{
+			name:   "accepts value at min boundary",
+			schema: UintSchema{Min: 10, Max: 100},
+			input:  uint(10),
+			want:   10,
+		},
+		{
+			name:   "accepts value at max boundary",
+			schema: UintSchema{Min: 0, Max: 100},
+			input:  uint(100),
+			want:   100,
+		},
+		{
+			name:   "accepts zero when min is zero",
+			schema: UintSchema{Min: 0, Max: 100},
+			input:  uint(0),
+			want:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.schema.ParseAndValidate(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errType != nil {
+					require.IsType(t, tt.errType, err)
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestUintSchema_TypeDescription(t *testing.T) {
+	schema := UintSchema{Min: 1, Max: 500}
+	desc := schema.TypeDescription()
+	require.Contains(t, desc, "unsigned integer")
+	require.Contains(t, desc, "1")
+	require.Contains(t, desc, "500")
+}

--- a/pkg/config/dynamic/types.go
+++ b/pkg/config/dynamic/types.go
@@ -1,0 +1,42 @@
+package dynamic
+
+import (
+	"github.com/storacha/piri/pkg/config"
+)
+
+// ChangeSource indicates where a configuration change originated.
+type ChangeSource string
+
+const (
+	// SourceAPI indicates the change came from the admin API.
+	SourceAPI ChangeSource = "api"
+	// SourceFile indicates the change came from a config file update.
+	SourceFile ChangeSource = "file"
+)
+
+// ChangeEvent represents a configuration change notification.
+type ChangeEvent struct {
+	// Key is the configuration key that changed.
+	Key config.Key
+	// OldValue is the previous value.
+	OldValue any
+	// NewValue is the new value.
+	NewValue any
+	// Source indicates where the change originated.
+	Source ChangeSource
+}
+
+// Observer is notified when configuration values change.
+type Observer interface {
+	// OnConfigChange is called when a configuration value changes.
+	// Implementations should be non-blocking and return quickly.
+	OnConfigChange(event ChangeEvent)
+}
+
+// ObserverFunc is a function adapter for the Observer interface.
+type ObserverFunc func(event ChangeEvent)
+
+// OnConfigChange implements Observer.
+func (f ObserverFunc) OnConfigChange(event ChangeEvent) {
+	f(event)
+}

--- a/pkg/config/dynamic/viper.go
+++ b/pkg/config/dynamic/viper.go
@@ -1,0 +1,159 @@
+package dynamic
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/spf13/viper"
+
+	"github.com/storacha/piri/pkg/config"
+)
+
+// ViperBridge bridges between Viper configuration and the dynamic Registry.
+// It provides methods to explicitly reload configuration from the config file.
+type ViperBridge struct {
+	mu       sync.RWMutex
+	v        *viper.Viper
+	registry *Registry
+}
+
+// NewViperBridge creates a new ViperBridge.
+func NewViperBridge(v *viper.Viper, registry *Registry) *ViperBridge {
+	return &ViperBridge{
+		v:        v,
+		registry: registry,
+	}
+}
+
+// Reload explicitly reloads config from the file.
+// Call this in response to admin API request or CLI command.
+// Returns an error if the config file cannot be read or if any value fails validation.
+// On validation failure, no values are updated (fail-fast behavior).
+func (vb *ViperBridge) Reload() error {
+	vb.mu.Lock()
+	defer vb.mu.Unlock()
+
+	if vb.registry == nil {
+		return fmt.Errorf("registry not set")
+	}
+
+	// Re-read the config file
+	if err := vb.v.ReadInConfig(); err != nil {
+		return fmt.Errorf("reading config file: %w", err)
+	}
+
+	log.Info("Reloading config from file")
+
+	// Build updates map from viper values for all registered keys
+	updates := make(map[string]any)
+
+	for _, key := range vb.registry.Keys() {
+		keyStr := string(key)
+		if vb.v.IsSet(keyStr) {
+			// Get the raw value from viper - it will be parsed by the registry's schema
+			updates[keyStr] = vb.v.Get(keyStr)
+		}
+	}
+
+	if len(updates) == 0 {
+		log.Info("No config values to reload")
+		return nil
+	}
+
+	// Don't persist since we're loading from file
+	// Registry will validate all values - if any fail, the entire reload fails
+	if err := vb.registry.Update(updates, false, SourceFile); err != nil {
+		return fmt.Errorf("applying config changes: %w", err)
+	}
+
+	log.Infow("Config reloaded successfully", "keys_updated", len(updates))
+	return nil
+}
+
+// TOMLPersister implements surgical TOML file updates.
+// Unlike Viper's WriteConfig which dumps all values, this persister
+// reads the existing file, updates only the changed keys, and writes back
+// preserving all other content.
+type TOMLPersister struct {
+	mu       sync.Mutex
+	filePath string
+}
+
+// NewTOMLPersister creates a new TOMLPersister.
+func NewTOMLPersister(filePath string) *TOMLPersister {
+	return &TOMLPersister{filePath: filePath}
+}
+
+// Persist writes only the specified config changes to the config file.
+func (p *TOMLPersister) Persist(updates map[config.Key]any) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Read existing file
+	data, err := os.ReadFile(p.filePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("reading config file: %w", err)
+	}
+
+	// Parse TOML into a map to preserve structure
+	var cfg map[string]any
+	if len(data) > 0 {
+		if err := toml.Unmarshal(data, &cfg); err != nil {
+			return fmt.Errorf("parsing config file: %w", err)
+		}
+	} else {
+		cfg = make(map[string]any)
+	}
+
+	// Apply only the updates
+	for key, value := range updates {
+		setNestedValue(cfg, string(key), value)
+	}
+
+	// Write back
+	out, err := toml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+
+	if err := os.WriteFile(p.filePath, out, 0644); err != nil {
+		return fmt.Errorf("writing config file: %w", err)
+	}
+
+	log.Infow("Config persisted to file", "file", p.filePath, "updates", len(updates))
+	return nil
+}
+
+// setNestedValue sets a value in a nested map using dot-notation key.
+// e.g., "pdp.aggregation.poll_interval" -> config["pdp"]["aggregation"]["poll_interval"]
+func setNestedValue(m map[string]any, key string, value any) {
+	parts := strings.Split(key, ".")
+	current := m
+
+	// Navigate/create the nested structure
+	for _, part := range parts[:len(parts)-1] {
+		if _, ok := current[part]; !ok {
+			current[part] = make(map[string]any)
+		}
+		if next, ok := current[part].(map[string]any); ok {
+			current = next
+		} else {
+			// Path exists but isn't a map, need to overwrite
+			newMap := make(map[string]any)
+			current[part] = newMap
+			current = newMap
+		}
+	}
+
+	// Format duration values as strings for TOML
+	switch v := value.(type) {
+	case time.Duration:
+		current[parts[len(parts)-1]] = v.String()
+	default:
+		current[parts[len(parts)-1]] = value
+	}
+}

--- a/pkg/config/dynamic/viper_test.go
+++ b/pkg/config/dynamic/viper_test.go
@@ -1,0 +1,309 @@
+package dynamic
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/storacha/piri/pkg/config"
+)
+
+func TestNewTOMLPersister(t *testing.T) {
+	p := NewTOMLPersister("/some/path/config.toml")
+	require.NotNil(t, p)
+	require.Equal(t, "/some/path/config.toml", p.filePath)
+}
+
+func TestTOMLPersister_Persist(t *testing.T) {
+	t.Run("creates file if doesn't exist", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "config.toml")
+
+		p := NewTOMLPersister(filePath)
+		err := p.Persist(map[config.Key]any{
+			"test.value": "hello",
+		})
+		require.NoError(t, err)
+
+		// Verify file was created
+		data, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+
+		var cfg map[string]any
+		err = toml.Unmarshal(data, &cfg)
+		require.NoError(t, err)
+
+		testSection, ok := cfg["test"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "hello", testSection["value"])
+	})
+
+	t.Run("updates existing file preserving other content", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "config.toml")
+
+		// Create initial file with some content
+		initialContent := `
+[server]
+port = 8080
+host = "localhost"
+
+[database]
+connection = "postgres://localhost"
+`
+		err := os.WriteFile(filePath, []byte(initialContent), 0644)
+		require.NoError(t, err)
+
+		p := NewTOMLPersister(filePath)
+		err = p.Persist(map[config.Key]any{
+			"server.timeout": "30s",
+		})
+		require.NoError(t, err)
+
+		// Read and verify
+		data, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+
+		var cfg map[string]any
+		err = toml.Unmarshal(data, &cfg)
+		require.NoError(t, err)
+
+		// Original values should be preserved
+		server, ok := cfg["server"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, int64(8080), server["port"])
+		require.Equal(t, "localhost", server["host"])
+		require.Equal(t, "30s", server["timeout"]) // New value
+
+		// Other sections should be preserved
+		database, ok := cfg["database"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "postgres://localhost", database["connection"])
+	})
+
+	t.Run("handles nested keys with dot notation", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "config.toml")
+
+		p := NewTOMLPersister(filePath)
+		err := p.Persist(map[config.Key]any{
+			"pdp.aggregation.manager.poll_interval": "5m",
+		})
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+
+		var cfg map[string]any
+		err = toml.Unmarshal(data, &cfg)
+		require.NoError(t, err)
+
+		pdp, ok := cfg["pdp"].(map[string]any)
+		require.True(t, ok)
+		aggregation, ok := pdp["aggregation"].(map[string]any)
+		require.True(t, ok)
+		manager, ok := aggregation["manager"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "5m", manager["poll_interval"])
+	})
+
+	t.Run("formats duration as string", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "config.toml")
+
+		p := NewTOMLPersister(filePath)
+		err := p.Persist(map[config.Key]any{
+			"test.duration": 5 * time.Minute,
+		})
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+
+		var cfg map[string]any
+		err = toml.Unmarshal(data, &cfg)
+		require.NoError(t, err)
+
+		testSection, ok := cfg["test"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "5m0s", testSection["duration"])
+	})
+
+	t.Run("handles multiple updates in single call", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "config.toml")
+
+		p := NewTOMLPersister(filePath)
+		err := p.Persist(map[config.Key]any{
+			"server.port":    8080,
+			"server.timeout": 30 * time.Second,
+			"database.max":   100,
+		})
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+
+		var cfg map[string]any
+		err = toml.Unmarshal(data, &cfg)
+		require.NoError(t, err)
+
+		server, ok := cfg["server"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, int64(8080), server["port"])
+		require.Equal(t, "30s", server["timeout"])
+
+		database, ok := cfg["database"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, int64(100), database["max"])
+	})
+
+	t.Run("returns error for invalid file path", func(t *testing.T) {
+		p := NewTOMLPersister("/nonexistent/directory/config.toml")
+		err := p.Persist(map[config.Key]any{
+			"test.value": "hello",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("returns error for malformed TOML file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "config.toml")
+
+		// Write invalid TOML
+		err := os.WriteFile(filePath, []byte("this is not valid toml {{{{"), 0644)
+		require.NoError(t, err)
+
+		p := NewTOMLPersister(filePath)
+		err = p.Persist(map[config.Key]any{
+			"test.value": "hello",
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "parsing config file")
+	})
+
+	t.Run("handles concurrent calls safely", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "config.toml")
+
+		p := NewTOMLPersister(filePath)
+
+		var wg sync.WaitGroup
+		iterations := 50
+
+		for i := 0; i < iterations; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				key := config.Key("test.value" + string(rune('a'+i%26)))
+				_ = p.Persist(map[config.Key]any{
+					key: i,
+				})
+			}(i)
+		}
+
+		wg.Wait()
+
+		// File should be readable and valid TOML
+		data, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+
+		var cfg map[string]any
+		err = toml.Unmarshal(data, &cfg)
+		require.NoError(t, err)
+		require.NotEmpty(t, cfg)
+	})
+}
+
+func TestSetNestedValue(t *testing.T) {
+	t.Run("creates nested structure for dotted key", func(t *testing.T) {
+		m := make(map[string]any)
+		setNestedValue(m, "a.b.c", "value")
+
+		a, ok := m["a"].(map[string]any)
+		require.True(t, ok)
+		b, ok := a["b"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "value", b["c"])
+	})
+
+	t.Run("handles single-level key", func(t *testing.T) {
+		m := make(map[string]any)
+		setNestedValue(m, "key", "value")
+
+		require.Equal(t, "value", m["key"])
+	})
+
+	t.Run("overwrites non-map intermediate value", func(t *testing.T) {
+		m := map[string]any{
+			"a": "string-value", // Not a map
+		}
+		setNestedValue(m, "a.b.c", "value")
+
+		// "a" should now be a map
+		a, ok := m["a"].(map[string]any)
+		require.True(t, ok)
+		b, ok := a["b"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "value", b["c"])
+	})
+
+	t.Run("preserves existing nested values", func(t *testing.T) {
+		m := map[string]any{
+			"a": map[string]any{
+				"existing": "value",
+			},
+		}
+		setNestedValue(m, "a.new", "new-value")
+
+		a, ok := m["a"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "value", a["existing"])
+		require.Equal(t, "new-value", a["new"])
+	})
+
+	t.Run("formats duration as string", func(t *testing.T) {
+		m := make(map[string]any)
+		setNestedValue(m, "config.timeout", 5*time.Minute)
+
+		config, ok := m["config"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "5m0s", config["timeout"])
+	})
+
+	t.Run("handles deep nesting", func(t *testing.T) {
+		m := make(map[string]any)
+		setNestedValue(m, "level1.level2.level3.level4.level5", "deep-value")
+
+		current := m
+		for _, level := range []string{"level1", "level2", "level3", "level4"} {
+			next, ok := current[level].(map[string]any)
+			require.True(t, ok, "expected map at %s", level)
+			current = next
+		}
+		require.Equal(t, "deep-value", current["level5"])
+	})
+
+	t.Run("handles various value types", func(t *testing.T) {
+		m := make(map[string]any)
+
+		setNestedValue(m, "types.string", "hello")
+		setNestedValue(m, "types.int", 42)
+		setNestedValue(m, "types.uint", uint(100))
+		setNestedValue(m, "types.float", 3.14)
+		setNestedValue(m, "types.bool", true)
+
+		types, ok := m["types"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "hello", types["string"])
+		require.Equal(t, 42, types["int"])
+		require.Equal(t, uint(100), types["uint"])
+		require.Equal(t, 3.14, types["float"])
+		require.Equal(t, true, types["bool"])
+	})
+}

--- a/pkg/fx/app/common.go
+++ b/pkg/fx/app/common.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/storacha/piri/pkg/admin"
 	"github.com/storacha/piri/pkg/config/app"
+	"github.com/storacha/piri/pkg/config/dynamic"
 	"github.com/storacha/piri/pkg/fx/database"
 	"github.com/storacha/piri/pkg/fx/echo"
 	"github.com/storacha/piri/pkg/fx/identity"
@@ -25,11 +26,13 @@ func CommonModules(cfg app.AppConfig) fx.Option {
 		fx.Supply(cfg.PDPService),
 		fx.Supply(cfg.Replicator),
 		fx.Supply(cfg.PDPService.SigningService),
+		fx.Supply(cfg.PDPService.Aggregation.Manager),
 
 		identity.Module, // Provides principal.Signer
 		proofs.Module,   // Provides service for requesting service proofs
 		echo.Module,     // Provides Echo server with route registration
 		database.Module, // Provides SQLite database for job queues
+		dynamic.Module,  // Provides dynamic configuration registry
 
 		admin.Module, // Provides admin module with http routes.
 	}

--- a/pkg/pdp/aggregation/manager/config.go
+++ b/pkg/pdp/aggregation/manager/config.go
@@ -1,0 +1,71 @@
+package manager
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/storacha/piri/pkg/config"
+	"github.com/storacha/piri/pkg/config/app"
+	"github.com/storacha/piri/pkg/config/dynamic"
+)
+
+// ConfigProvider provides dynamic configuration for the Manager.
+type ConfigProvider interface {
+	// PollInterval returns the current poll interval for the aggregation manager.
+	PollInterval() time.Duration
+
+	// BatchSize returns the current maximum batch size.
+	BatchSize() uint
+
+	// Subscribe registers an observer for config changes on the specified key.
+	// Use config.Key constants (e.g., config.ManagerPollInterval).
+	// Returns a function to unsubscribe.
+	Subscribe(key config.Key, fn func(old, new any)) (func(), error)
+}
+
+// dynamicConfigProvider implements ConfigProvider using the dynamic registry.
+type dynamicConfigProvider struct {
+	registry *dynamic.Registry
+	fallback app.AggregateManagerConfig
+}
+
+// NewConfigProvider creates a ConfigProvider backed by the dynamic registry.
+// It registers the manager's config entries with the registry during creation.
+func NewConfigProvider(
+	registry *dynamic.Registry,
+	cfg app.AggregateManagerConfig,
+) (ConfigProvider, error) {
+
+	// Register this package's config entries with their schemas
+	if err := registry.RegisterEntries(map[config.Key]dynamic.ConfigEntry{
+		config.ManagerPollInterval: {
+			Value:  cfg.PollInterval,
+			Schema: dynamic.DurationSchema{Min: time.Second, Max: 365 * 24 * time.Hour},
+		},
+		config.ManagerBatchSize: {
+			Value:  cfg.BatchSize,
+			Schema: dynamic.UintSchema{Min: 1, Max: 500},
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("registering config entries: %w", err)
+	}
+
+	return &dynamicConfigProvider{
+		registry: registry,
+		fallback: cfg,
+	}, nil
+}
+
+func (p *dynamicConfigProvider) PollInterval() time.Duration {
+	return p.registry.GetDuration(config.ManagerPollInterval, p.fallback.PollInterval)
+}
+
+func (p *dynamicConfigProvider) BatchSize() uint {
+	return p.registry.GetUint(config.ManagerBatchSize, p.fallback.BatchSize)
+}
+
+func (p *dynamicConfigProvider) Subscribe(key config.Key, fn func(old, new any)) (func(), error) {
+	return p.registry.SubscribeFunc(key, func(event dynamic.ChangeEvent) {
+		fn(event.OldValue, event.NewValue)
+	})
+}

--- a/pkg/pdp/aggregation/manager/fxmodule.go
+++ b/pkg/pdp/aggregation/manager/fxmodule.go
@@ -6,6 +6,7 @@ import (
 
 var Module = fx.Module("aggregation/manager",
 	fx.Provide(
+		NewConfigProvider,
 		NewManager,
 		NewSubmissionWorkspace,
 		NewAddRootsTaskHandler,


### PR DESCRIPTION
## Summary

Introduce a dynamic configuration system that allows operators to tune the aggregation manager's behavior at runtime without restarting piri. This enables gas usage optimization by adjusting how frequently the manager polls for work and how many roots it batches together when adding to the chain.

## Motivation

The aggregation manager is responsible for batching aggregated roots and submitting them on-chain. The cost of these operations depends on:
- **Poll interval**: How frequently the manager checks for pending work
- **Batch size**: How many roots are aggregated into a single on-chain submission

Previously, changing these values required editing the config file and restarting piri. This PR enables operators to:
1. Adjust configuration at runtime via CLI or HTTP API
2. Optionally persist changes to the config file
3. Reload configuration from file without restart

## Changes

### Core Dynamic Config Infrastructure (`pkg/config/dynamic/`)

**Key design decisions:**
- Schemas handle both parsing (string → typed) and validation in one step
- Updates are atomic: validate all values before applying any
- Persist failures trigger automatic rollback of in-memory changes
- Observer notifications happen outside the lock to prevent deadlocks

### Manager Integration (`pkg/pdp/aggregation/manager/`)

**Dynamic behavior:**
- `PollInterval`: When changed, the manager's ticker immediately resets to the new interval
- `BatchSize`: Read on each poll cycle, no subscription needed

### HTTP API (`pkg/admin/httpapi/`)

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/admin/config` | GET | List all dynamic config values |
| `/admin/config` | PATCH | Update config values (with optional persist) |
| `/admin/config/reload` | POST | Reload config from file |

### CLI Commands (`cmd/cli/client/admin/config/`)

```bash
# List all dynamic config values
piri client admin config list

# Get a specific value
piri client admin config get pdp.aggregation.manager.poll_interval

# Set a value (in-memory only)
piri client admin config set pdp.aggregation.manager.poll_interval 5m

# Set and persist to config file
piri client admin config set pdp.aggregation.manager.poll_interval 5m --persist

# Reload config from file
piri client admin config reload
```

### Config Keys

| Key | Type | Range | Default |
|-----|------|-------|---------|
| `pdp.aggregation.manager.poll_interval` | Duration | 1s - 1 year | 30s (unchanged) |
| `pdp.aggregation.manager.batch_size` | Uint | 1 - 500 | 10 (unchanged) |


## Example Usage

**Scenario**: Operator wants to reduce gas costs by batching more roots together and polling less frequently.

```bash
# Check current values
$ piri client admin config list
{
  "pdp.aggregation.manager.batch_size": 100,
  "pdp.aggregation.manager.poll_interval": "30s"
}

# Increase batch size and poll interval, persist to survive restart
$ piri client admin config set pdp.aggregation.manager.batch_size 200 --persist
$ piri client admin config set pdp.aggregation.manager.poll_interval 2m --persist

# Changes take effect immediately - no restart needed
```
