### PR TITLE
revert: allocation store key format hack

### DIFF
--- a/pkg/store/allocationstore/datastore.go
+++ b/pkg/store/allocationstore/datastore.go
@@ -22,26 +22,6 @@ type DsAllocationStore struct {
 
 func (d *DsAllocationStore) Get(ctx context.Context, digest multihash.Multihash, space did.DID) (allocation.Allocation, error) {
 	value, err := d.data.Get(ctx, datastore.NewKey(encodeKey(digest, space)))
-
-	// HACK: (ash) Temporary hack to allow allocation to be found if it was
-	// stored with the old style key ("<digest>/<cause>") not the new key
-	// ("<digest>/<space>"). This works because listing works on digest
-	// prefix i.e. "<digest>/*".
-	//
-	// This code is safe to be removed after the next time we reset the
-	// warm storage network.
-	if err != nil && errors.Is(err, store.ErrNotFound) {
-		allocs, listErr := d.List(ctx, digest)
-		if listErr != nil {
-			return allocation.Allocation{}, fmt.Errorf("listing from datastore: %w", listErr)
-		}
-		for _, a := range allocs {
-			if a.Space == space {
-				return a, nil
-			}
-		}
-	}
-
 	if err != nil {
 		if errors.Is(err, datastore.ErrNotFound) {
 			return allocation.Allocation{}, store.ErrNotFound


### PR DESCRIPTION
This PR reverts https://github.com/storacha/piri/pull/253 which is now safe since a new Piri version was released and operators all wiped their stores. I have purposely not removed the hack from [`pkg/aws/dynamoallocationstore.go`](https://github.com/storacha/piri/pull/253/changes#diff-ff341b1145d241467a2a288107d35c4fc90e654d39660af9fcd6198f4c8d3430) since live data still exists in production with the old key format.

resolves #255