### PR TITLE
config: fix default config setting for init

### DIFF
--- a/cmd/cli/setup/register.go
+++ b/cmd/cli/setup/register.go
@@ -441,6 +441,7 @@ func createNode(ctx context.Context, flags *initFlags) (*fx.App, *service.PDPSer
 			},
 			ChainID:      flags.baseConfig.chainID,
 			PayerAddress: flags.baseConfig.payerAddress,
+			Aggregation:  config.DefaultAggregationConfig(),
 		}.ToAppConfig()),
 		Replicator: appcfg.DefaultReplicatorConfig(),
 	}
@@ -731,6 +732,7 @@ func generateConfig(cfg *appcfg.AppConfig, flags *initFlags, ownerAddress common
 			},
 			ChainID:      flags.baseConfig.chainID,
 			PayerAddress: flags.baseConfig.payerAddress,
+			Aggregation:  config.DefaultAggregationConfig(),
 		},
 		UCANService: config.UCANServiceConfig{
 			Services: config.ServicesConfig{

--- a/pkg/config/app/pdp.go
+++ b/pkg/config/app/pdp.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"math/big"
 	"net/url"
+	"runtime"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -74,4 +75,35 @@ type JobQueueConfig struct {
 	Retries uint
 	// The duration between successive retries
 	RetryDelay time.Duration
+}
+
+// DefaultJobQueueConfig returns a JobQueueConfig with sensible defaults.
+func DefaultJobQueueConfig() JobQueueConfig {
+	return JobQueueConfig{
+		Workers:    uint(runtime.NumCPU()),
+		Retries:    50,
+		RetryDelay: 10 * time.Second,
+	}
+}
+
+// DefaultAggregateManagerConfig returns an AggregateManagerConfig with sensible defaults.
+func DefaultAggregateManagerConfig() AggregateManagerConfig {
+	return AggregateManagerConfig{
+		PollInterval: 30 * time.Second,
+		BatchSize:    10,
+		JobQueue: JobQueueConfig{
+			Workers:    3,
+			Retries:    50,
+			RetryDelay: time.Minute,
+		},
+	}
+}
+
+// DefaultAggregationConfig returns an AggregationConfig with sensible defaults.
+func DefaultAggregationConfig() AggregationConfig {
+	return AggregationConfig{
+		CommP:      CommpConfig{JobQueue: DefaultJobQueueConfig()},
+		Aggregator: AggregatorConfig{JobQueue: DefaultJobQueueConfig()},
+		Manager:    DefaultAggregateManagerConfig(),
+	}
 }

--- a/pkg/config/pdp.go
+++ b/pkg/config/pdp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"net/url"
+	"runtime"
 	"strings"
 	"time"
 
@@ -261,4 +262,34 @@ func (c AggregationConfig) ToAppConfig() (app.AggregationConfig, error) {
 		},
 		Manager: managerCfg,
 	}, nil
+}
+
+// DefaultAggregationConfig returns an AggregationConfig with sensible defaults.
+// These values match the viper defaults in defaults.go.
+func DefaultAggregationConfig() AggregationConfig {
+	return AggregationConfig{
+		CommP: CommpConfig{
+			JobQueue: JobQueueConfig{
+				Workers:    uint(runtime.NumCPU()),
+				Retries:    50,
+				RetryDelay: 10 * time.Second,
+			},
+		},
+		Aggregator: AggregatorConfig{
+			JobQueue: JobQueueConfig{
+				Workers:    uint(runtime.NumCPU()),
+				Retries:    50,
+				RetryDelay: 10 * time.Second,
+			},
+		},
+		Manager: AggregateManagerConfig{
+			PollInterval: 30 * time.Second,
+			BatchSize:    10,
+			JobQueue: JobQueueConfig{
+				Workers:    3,
+				Retries:    50,
+				RetryDelay: time.Minute,
+			},
+		},
+	}
 }


### PR DESCRIPTION
fixes a bug introduced by https://github.com/storacha/piri/pull/409, these values now that they are configurable need defaults set for the case when they are absent from any user supplied configuration