### PR TITLE
feat(pdp): add repair command to reconcile stuck roots with on-chain state

### DIFF
--- a/cmd/cli/client/pdp/proofset/repair.go
+++ b/cmd/cli/client/pdp/proofset/repair.go
@@ -1,0 +1,69 @@
+package proofset
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/storacha/piri/pkg/config"
+	"github.com/storacha/piri/pkg/pdp/httpapi/client"
+)
+
+var (
+	RepairCmd = &cobra.Command{
+		Use:   "repair",
+		Short: "Repair a proof set by reconciling stuck roots with on-chain state",
+		Long: `Repair a proof set by comparing on-chain state with the database.
+
+This command fetches all active pieces from the blockchain contract and compares
+them with the roots stored in the database. Any pieces that exist on-chain but
+are missing from the database (due to Lotus state loss or other issues) will be
+repaired using metadata from pending root additions.
+
+Use this command when the PDP proving pipeline is stuck because roots were added
+to the blockchain but never recorded in the database.`,
+		Args: cobra.NoArgs,
+		RunE: doRepair,
+	}
+)
+
+func init() {
+	RepairCmd.Flags().Uint64(
+		"proofset-id",
+		0,
+		"The proof set ID to repair",
+	)
+	cobra.CheckErr(viper.BindPFlag("ucan.proof_set", RepairCmd.Flags().Lookup("proofset-id")))
+}
+
+func doRepair(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+
+	cfg, err := config.Load[config.Client]()
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	if cfg.UCAN.ProofSetID == 0 {
+		return fmt.Errorf("proofset-id required, provide it with '--proofset-id' flag, or pass a valid config file")
+	}
+
+	api, err := client.NewFromConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("creating client: %w", err)
+	}
+
+	result, err := api.RepairProofSet(ctx, cfg.UCAN.ProofSetID)
+	if err != nil {
+		return fmt.Errorf("repairing proof set: %w", err)
+	}
+
+	jsonResult, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("rendering json: %w", err)
+	}
+	cmd.Print(string(jsonResult))
+	return nil
+}

--- a/cmd/cli/client/pdp/proofset/root.go
+++ b/cmd/cli/client/pdp/proofset/root.go
@@ -18,4 +18,5 @@ func init() {
 	Cmd.AddCommand(GetCmd)
 	Cmd.AddCommand(StateCmd)
 	Cmd.AddCommand(ListCmd)
+	Cmd.AddCommand(RepairCmd)
 }

--- a/pkg/pdp/httpapi/client/client.go
+++ b/pkg/pdp/httpapi/client/client.go
@@ -355,6 +355,51 @@ func (c *Client) ListProofSet(ctx context.Context) ([]types.ProofSet, error) {
 	return out, nil
 }
 
+func (c *Client) RepairProofSet(ctx context.Context, proofSetID uint64) (*types.RepairResult, error) {
+	if !c.isPiriServer() {
+		return nil, fmt.Errorf("method requires piri server implementation: unsupported method")
+	}
+	route := c.endpoint.JoinPath(pdpRoutePath, proofSetsPath, strconv.FormatUint(proofSetID, 10), "repair").String()
+	res, err := c.postJson(ctx, route, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to repair proof set: %w", err)
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil, errFromResponse(res)
+	}
+	var resp httpapi.RepairProofSetResponse
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("failed to decode repair response: %w", err)
+	}
+
+	result := &types.RepairResult{
+		TotalOnChain:      resp.TotalOnChain,
+		TotalInDB:         resp.TotalInDB,
+		TotalRepaired:     resp.TotalRepaired,
+		TotalUnrepaired:   resp.TotalUnrepaired,
+		RepairedEntries:   make([]types.RepairedEntry, len(resp.RepairedEntries)),
+		UnrepairedEntries: make([]types.UnrepairedEntry, len(resp.UnrepairedEntries)),
+	}
+
+	for i, entry := range resp.RepairedEntries {
+		result.RepairedEntries[i] = types.RepairedEntry{
+			RootCID:  entry.RootCID,
+			RootID:   entry.RootID,
+			Subroots: entry.Subroots,
+		}
+	}
+
+	for i, entry := range resp.UnrepairedEntries {
+		result.UnrepairedEntries[i] = types.UnrepairedEntry{
+			RootCID: entry.RootCID,
+			RootID:  entry.RootID,
+			Reason:  entry.Reason,
+		}
+	}
+
+	return result, nil
+}
+
 func (c *Client) AddRoots(ctx context.Context, proofSetID uint64, roots []types.RootAdd) (common.Hash, error) {
 	route := c.endpoint.JoinPath(pdpRoutePath, proofSetsPath, "/", strconv.FormatUint(proofSetID, 10), rootsPath).String()
 

--- a/pkg/pdp/httpapi/server/register.go
+++ b/pkg/pdp/httpapi/server/register.go
@@ -57,6 +57,7 @@ func (p *PDPHandler) RegisterRoutes(e *echo.Echo) {
 	proofSets.DELETE("/:proofSetID", p.handleDeleteProofSet)
 	proofSets.GET("", p.handleListProofSet)
 	proofSets.GET("/:proofSetID/state", p.handleGetProofSetState)
+	proofSets.POST("/:proofSetID/repair", p.handleRepairProofSet)
 
 	// /pdp/proof-sets/:proofSetID/roots
 	roots := proofSets.Group("/:proofSetID/roots")

--- a/pkg/pdp/httpapi/server/repair_proofset.go
+++ b/pkg/pdp/httpapi/server/repair_proofset.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/storacha/piri/pkg/pdp/httpapi"
+)
+
+// handleRepairProofSet -> POST /pdp/proof-sets/:proofSetID/repair
+func (p *PDPHandler) handleRepairProofSet(c echo.Context) error {
+	ctx := c.Request().Context()
+	proofSetIDStr := c.Param("proofSetID")
+
+	if proofSetIDStr == "" {
+		return c.String(http.StatusBadRequest, "missing proofSetID")
+	}
+
+	id, err := strconv.ParseUint(proofSetIDStr, 10, 64)
+	if err != nil {
+		return c.String(http.StatusBadRequest, "invalid proofSetID")
+	}
+
+	result, err := p.Service.RepairProofSet(ctx, id)
+	if err != nil {
+		log.Errorw("failed to repair proof set", "proofSetID", id, "error", err)
+		return c.String(http.StatusInternalServerError, "failed to repair proof set: "+err.Error())
+	}
+
+	resp := httpapi.RepairProofSetResponse{
+		TotalOnChain:      result.TotalOnChain,
+		TotalInDB:         result.TotalInDB,
+		TotalRepaired:     result.TotalRepaired,
+		TotalUnrepaired:   result.TotalUnrepaired,
+		RepairedEntries:   make([]httpapi.RepairedEntry, len(result.RepairedEntries)),
+		UnrepairedEntries: make([]httpapi.UnrepairedEntry, len(result.UnrepairedEntries)),
+	}
+
+	for i, entry := range result.RepairedEntries {
+		resp.RepairedEntries[i] = httpapi.RepairedEntry{
+			RootCID:  entry.RootCID,
+			RootID:   entry.RootID,
+			Subroots: entry.Subroots,
+		}
+	}
+
+	for i, entry := range result.UnrepairedEntries {
+		resp.UnrepairedEntries[i] = httpapi.UnrepairedEntry{
+			RootCID: entry.RootCID,
+			RootID:  entry.RootID,
+			Reason:  entry.Reason,
+		}
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}

--- a/pkg/pdp/httpapi/types.go
+++ b/pkg/pdp/httpapi/types.go
@@ -202,3 +202,30 @@ type (
 		IsApproved         bool   `json:"isApproved"`
 	}
 )
+
+// RepairProofSet types
+type (
+	RepairProofSetResponse struct {
+		// State comparison
+		TotalOnChain int `json:"totalOnChain"` // Active pieces on chain
+		TotalInDB    int `json:"totalInDB"`    // Roots in pdp_proofset_roots
+
+		// Repair results
+		TotalRepaired     int               `json:"totalRepaired"`
+		TotalUnrepaired   int               `json:"totalUnrepaired"`
+		RepairedEntries   []RepairedEntry   `json:"repairedEntries"`
+		UnrepairedEntries []UnrepairedEntry `json:"unrepairedEntries"`
+	}
+
+	RepairedEntry struct {
+		RootCID  string `json:"rootCid"`
+		RootID   uint64 `json:"rootId"`
+		Subroots int    `json:"subrootsRepaired"`
+	}
+
+	UnrepairedEntry struct {
+		RootCID string `json:"rootCid"`
+		RootID  uint64 `json:"rootId"`
+		Reason  string `json:"reason"`
+	}
+)

--- a/pkg/pdp/service/proofset_repair.go
+++ b/pkg/pdp/service/proofset_repair.go
@@ -1,0 +1,282 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/storacha/piri/pkg/pdp/service/models"
+	"github.com/storacha/piri/pkg/pdp/smartcontracts"
+	"github.com/storacha/piri/pkg/pdp/types"
+)
+
+// ActivePiecesProvider abstracts the chain state queries needed for repair.
+// This interface allows for easier testing by mocking chain interactions.
+type ActivePiecesProvider interface {
+	GetActivePieceCount(ctx context.Context, setId *big.Int) (*big.Int, error)
+	GetActivePieces(ctx context.Context, setID *big.Int, offset *big.Int, limit *big.Int) (*smartcontracts.ActivePieces, error)
+}
+
+// RepairProofSet reconciles the on-chain state with the database state for a proof set.
+// It fetches all active pieces from the chain, compares with pdp_proofset_roots,
+// and repairs any gaps using metadata from pdp_proofset_root_adds.
+func (p *PDPService) RepairProofSet(ctx context.Context, proofSetID uint64) (res *types.RepairResult, retErr error) {
+	log.Infow("repairing proof set", "proofSetID", proofSetID)
+	defer func() {
+		if retErr != nil {
+			log.Errorw("failed to repair proof set", "proofSetID", proofSetID, "err", retErr)
+		} else {
+			log.Infow("repair completed", "proofSetID", proofSetID,
+				"totalOnChain", res.TotalOnChain,
+				"totalInDB", res.TotalInDB,
+				"totalRepaired", res.TotalRepaired,
+				"totalUnrepaired", res.TotalUnrepaired)
+		}
+	}()
+
+	return repairProofSetCore(ctx, p.db, p.verifierContract, proofSetID)
+}
+
+// repairProofSetCore contains the core repair logic with explicit dependencies.
+// This function is extracted to enable unit testing without constructing a full PDPService.
+func repairProofSetCore(
+	ctx context.Context,
+	db *gorm.DB,
+	chainProvider ActivePiecesProvider,
+	proofSetID uint64,
+) (*types.RepairResult, error) {
+	// Verify the proof set exists
+	var proofSet models.PDPProofSet
+	if err := db.WithContext(ctx).First(&proofSet, proofSetID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, types.NewErrorf(types.KindNotFound, "proof set %d not found", proofSetID)
+		}
+		return nil, fmt.Errorf("failed to retrieve proof set: %w", err)
+	}
+
+	// Step 1: Get chain state - all active pieces from the contract
+	chainPieces, err := getAllActivePiecesCore(ctx, chainProvider, proofSetID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get active pieces from chain: %w", err)
+	}
+
+	// Step 2: Get database state - distinct roots from pdp_proofset_roots
+	var dbRoots []string
+	if err := db.WithContext(ctx).
+		Model(&models.PDPProofsetRoot{}).
+		Where("proofset_id = ?", proofSetID).
+		Distinct("root").
+		Pluck("root", &dbRoots).Error; err != nil {
+		return nil, fmt.Errorf("failed to get roots from database: %w", err)
+	}
+
+	// Create a set of existing root CIDs for fast lookup
+	dbRootSet := make(map[string]struct{}, len(dbRoots))
+	for _, root := range dbRoots {
+		dbRootSet[root] = struct{}{}
+	}
+
+	// Step 3: Find gaps - pieces on chain but not in database
+	type missingRoot struct {
+		CID     string
+		PieceID uint64
+	}
+	var missingRoots []missingRoot
+
+	for cidStr, pieceID := range chainPieces {
+		if _, exists := dbRootSet[cidStr]; !exists {
+			missingRoots = append(missingRoots, missingRoot{
+				CID:     cidStr,
+				PieceID: pieceID,
+			})
+		}
+	}
+
+	result := &types.RepairResult{
+		TotalOnChain:      len(chainPieces),
+		TotalInDB:         len(dbRoots),
+		RepairedEntries:   []types.RepairedEntry{},
+		UnrepairedEntries: []types.UnrepairedEntry{},
+	}
+
+	// Step 4: If no gaps, return success
+	if len(missingRoots) == 0 {
+		log.Infow("no repair needed - chain and database are in sync",
+			"proofSetID", proofSetID,
+			"totalOnChain", len(chainPieces),
+			"totalInDB", len(dbRoots))
+		return result, nil
+	}
+
+	log.Infow("found gaps to repair",
+		"proofSetID", proofSetID,
+		"missingCount", len(missingRoots))
+
+	// Step 5: For each missing root, try to repair using pdp_proofset_root_adds
+	for _, missing := range missingRoots {
+		repaired, err := repairSingleRootCore(ctx, db, proofSetID, missing.CID, missing.PieceID)
+		if err != nil {
+			log.Warnw("failed to repair root",
+				"proofSetID", proofSetID,
+				"rootCID", missing.CID,
+				"pieceID", missing.PieceID,
+				"err", err)
+			result.UnrepairedEntries = append(result.UnrepairedEntries, types.UnrepairedEntry{
+				RootCID: missing.CID,
+				RootID:  missing.PieceID,
+				Reason:  err.Error(),
+			})
+			continue
+		}
+
+		result.RepairedEntries = append(result.RepairedEntries, types.RepairedEntry{
+			RootCID:  missing.CID,
+			RootID:   missing.PieceID,
+			Subroots: repaired,
+		})
+	}
+
+	result.TotalRepaired = len(result.RepairedEntries)
+	result.TotalUnrepaired = len(result.UnrepairedEntries)
+
+	return result, nil
+}
+
+// getAllActivePiecesCore fetches all active pieces from the chain with pagination.
+// Returns a map of CID string to PieceID.
+// This function is extracted to enable unit testing with a mock chain provider.
+func getAllActivePiecesCore(ctx context.Context, chainProvider ActivePiecesProvider, proofSetID uint64) (map[string]uint64, error) {
+	setID := big.NewInt(int64(proofSetID))
+
+	// Get total count first for logging
+	count, err := chainProvider.GetActivePieceCount(ctx, setID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get active piece count: %w", err)
+	}
+
+	log.Debugw("fetching active pieces from chain",
+		"proofSetID", proofSetID,
+		"totalCount", count.Uint64())
+
+	result := make(map[string]uint64)
+
+	// Paginate through all active pieces
+	offset := big.NewInt(0)
+	limit := big.NewInt(100) // Fetch 100 at a time
+
+	for {
+		activePieces, err := chainProvider.GetActivePieces(ctx, setID, offset, limit)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get active pieces at offset %d: %w", offset.Uint64(), err)
+		}
+
+		// Add pieces to result map
+		for i, pieceCID := range activePieces.Pieces {
+			cidStr := pieceCID.String()
+			pieceID := activePieces.PieceIds[i].Uint64()
+			result[cidStr] = pieceID
+		}
+
+		// Check if we've fetched all pieces
+		if !activePieces.HasMore {
+			break
+		}
+
+		// Move to next page
+		offset = new(big.Int).Add(offset, limit)
+	}
+
+	return result, nil
+}
+
+// repairSingleRootCore attempts to repair a single missing root using metadata from pdp_proofset_root_adds.
+// Returns the number of subroots repaired.
+// This function is extracted to enable unit testing with a mock database.
+func repairSingleRootCore(ctx context.Context, db *gorm.DB, proofSetID uint64, rootCID string, pieceID uint64) (int, error) {
+	// Look up metadata in pdp_proofset_root_adds
+	var rootAdds []models.PDPProofsetRootAdd
+	if err := db.WithContext(ctx).
+		Where("proofset_id = ? AND root = ?", proofSetID, rootCID).
+		Order("subroot_offset ASC").
+		Find(&rootAdds).Error; err != nil {
+		return 0, fmt.Errorf("failed to query pdp_proofset_root_adds: %w", err)
+	}
+
+	if len(rootAdds) == 0 {
+		return 0, fmt.Errorf("metadata not found in pdp_proofset_root_adds")
+	}
+
+	// Collect unique message hashes to mark as confirmed later
+	messageHashes := make(map[string]struct{})
+
+	// Perform the repair in a transaction
+	err := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Insert entries into pdp_proofset_roots
+		// Use ON CONFLICT DO NOTHING to handle race conditions with WatcherRootAdd
+		for _, entry := range rootAdds {
+			// Nil check for AddMessageIndex
+			var addMessageIndex int64
+			if entry.AddMessageIndex != nil {
+				addMessageIndex = *entry.AddMessageIndex
+			}
+
+			root := models.PDPProofsetRoot{
+				ProofsetID:      entry.ProofsetID,
+				RootID:          int64(pieceID),
+				SubrootOffset:   entry.SubrootOffset,
+				Root:            entry.Root,
+				AddMessageHash:  entry.AddMessageHash,
+				AddMessageIndex: addMessageIndex,
+				Subroot:         entry.Subroot,
+				SubrootSize:     entry.SubrootSize,
+				PDPPieceRefID:   entry.PDPPieceRefID,
+			}
+			if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&root).Error; err != nil {
+				return fmt.Errorf("failed to insert pdp_proofset_root: %w", err)
+			}
+
+			// Track message hash for later confirmation
+			messageHashes[entry.AddMessageHash] = struct{}{}
+		}
+
+		// Delete entries from pdp_proofset_root_adds
+		if err := tx.Where("proofset_id = ? AND root = ?", proofSetID, rootCID).
+			Delete(&models.PDPProofsetRootAdd{}).Error; err != nil {
+			return fmt.Errorf("failed to delete from pdp_proofset_root_adds: %w", err)
+		}
+
+		// Mark associated message_waits_eth entries as confirmed
+		// This prevents WatcherEth from continuing to poll for receipts that Lotus doesn't have
+		for msgHash := range messageHashes {
+			txSuccess := true
+			if err := tx.Model(&models.MessageWaitsEth{}).
+				Where("signed_tx_hash = ?", msgHash).
+				Where("tx_status = ?", "pending").
+				Updates(map[string]interface{}{
+					"tx_status":  "confirmed",
+					"tx_success": &txSuccess,
+				}).Error; err != nil {
+				return fmt.Errorf("failed to update message_waits_eth for %s: %w", msgHash, err)
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return 0, err
+	}
+
+	log.Infow("repaired root",
+		"proofSetID", proofSetID,
+		"rootCID", rootCID,
+		"pieceID", pieceID,
+		"subrootsRepaired", len(rootAdds),
+		"messagesMarkedConfirmed", len(messageHashes))
+
+	return len(rootAdds), nil
+}

--- a/pkg/pdp/service/proofset_repair_test.go
+++ b/pkg/pdp/service/proofset_repair_test.go
@@ -1,0 +1,759 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/storacha/piri/pkg/pdp/service/models"
+	"github.com/storacha/piri/pkg/pdp/smartcontracts"
+)
+
+// mockActivePiecesProvider implements ActivePiecesProvider for testing
+type mockActivePiecesProvider struct {
+	pieces    map[uint64]*smartcontracts.ActivePieces // keyed by offset
+	count     *big.Int
+	countErr  error
+	piecesErr error
+}
+
+func (m *mockActivePiecesProvider) GetActivePieceCount(ctx context.Context, setId *big.Int) (*big.Int, error) {
+	if m.countErr != nil {
+		return nil, m.countErr
+	}
+	return m.count, nil
+}
+
+func (m *mockActivePiecesProvider) GetActivePieces(ctx context.Context, setID *big.Int, offset *big.Int, limit *big.Int) (*smartcontracts.ActivePieces, error) {
+	if m.piecesErr != nil {
+		return nil, m.piecesErr
+	}
+	result, ok := m.pieces[offset.Uint64()]
+	if !ok {
+		return &smartcontracts.ActivePieces{HasMore: false}, nil
+	}
+	return result, nil
+}
+
+// setupRepairTestDB creates an in-memory SQLite database for repair tests
+func setupRepairTestDB(t *testing.T) *gorm.DB {
+	dbName := fmt.Sprintf("file:repair-test-%d?mode=memory&cache=shared", time.Now().UnixNano())
+	db, err := gorm.Open(sqlite.Open(dbName), &gorm.Config{})
+	require.NoError(t, err)
+
+	sqlDb, err := db.DB()
+	require.NoError(t, err)
+	sqlDb.SetMaxOpenConns(1)
+
+	// Migrate the models needed for repair tests
+	// Note: We need to create tables in order to respect foreign key constraints
+	// First create message_waits_eth, then pdp_proof_sets, then the dependent tables
+	err = db.AutoMigrate(
+		&models.MessageWaitsEth{},
+		&models.PDPProofSet{},
+		&models.PDPProofsetRoot{},
+		&models.PDPProofsetRootAdd{},
+	)
+	require.NoError(t, err)
+	return db
+}
+
+// testCID creates a test CID from the given data string
+func testCID(t *testing.T, data string) cid.Cid {
+	h, err := multihash.Sum([]byte(data), multihash.SHA2_256, -1)
+	require.NoError(t, err)
+	return cid.NewCidV1(cid.Raw, h)
+}
+
+func TestRepairProofSetCore_NoRepairNeeded(t *testing.T) {
+	ctx := context.Background()
+	db := setupRepairTestDB(t)
+	proofSetID := uint64(1)
+
+	// Setup: Create message wait first (for foreign key)
+	msgWait := models.MessageWaitsEth{SignedTxHash: "0x123", TxStatus: "confirmed"}
+	require.NoError(t, db.Create(&msgWait).Error)
+
+	// Setup: Create proof set
+	proofSet := models.PDPProofSet{ID: int64(proofSetID), CreateMessageHash: "0x123", Service: "test"}
+	require.NoError(t, db.Create(&proofSet).Error)
+
+	// Setup: Create root in DB
+	rootCID := testCID(t, "root1")
+	subrootCID := testCID(t, "subroot1")
+	dbRoot := models.PDPProofsetRoot{
+		ProofsetID:     int64(proofSetID),
+		RootID:         0,
+		SubrootOffset:  0,
+		Root:           rootCID.String(),
+		AddMessageHash: "0x123",
+		Subroot:        subrootCID.String(),
+		SubrootSize:    1024,
+	}
+	require.NoError(t, db.Create(&dbRoot).Error)
+
+	// Setup: Mock returns same root as on-chain
+	mock := &mockActivePiecesProvider{
+		count: big.NewInt(1),
+		pieces: map[uint64]*smartcontracts.ActivePieces{
+			0: {
+				Pieces:   []cid.Cid{rootCID},
+				PieceIds: []*big.Int{big.NewInt(0)},
+				HasMore:  false,
+			},
+		},
+	}
+
+	// Execute
+	result, err := repairProofSetCore(ctx, db, mock, proofSetID)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, 1, result.TotalOnChain)
+	require.Equal(t, 1, result.TotalInDB)
+	require.Equal(t, 0, result.TotalRepaired)
+	require.Equal(t, 0, result.TotalUnrepaired)
+}
+
+func TestRepairProofSetCore_RepairsGap(t *testing.T) {
+	ctx := context.Background()
+	db := setupRepairTestDB(t)
+	proofSetID := uint64(1)
+
+	// Setup: Create message wait (pending - simulates Lotus lost state)
+	msgWait := models.MessageWaitsEth{SignedTxHash: "0x456", TxStatus: "pending"}
+	require.NoError(t, db.Create(&msgWait).Error)
+
+	// Setup: Create proof set
+	proofSet := models.PDPProofSet{ID: int64(proofSetID), CreateMessageHash: "0x456", Service: "test"}
+	require.NoError(t, db.Create(&proofSet).Error)
+
+	// Setup: Root exists on-chain but NOT in pdp_proofset_roots
+	rootCID := testCID(t, "missing-root")
+	subrootCID := testCID(t, "missing-subroot")
+	pieceID := uint64(42)
+
+	// Setup: Metadata exists in pdp_proofset_root_adds (stuck state)
+	addMsgIndex := int64(0)
+	rootAdd := models.PDPProofsetRootAdd{
+		ProofsetID:      int64(proofSetID),
+		AddMessageHash:  "0x456",
+		SubrootOffset:   0,
+		Root:            rootCID.String(),
+		AddMessageOK:    nil, // NULL - simulates stuck state
+		AddMessageIndex: &addMsgIndex,
+		Subroot:         subrootCID.String(),
+		SubrootSize:     2048,
+	}
+	require.NoError(t, db.Create(&rootAdd).Error)
+
+	// Setup: Mock returns this root as active on-chain
+	mock := &mockActivePiecesProvider{
+		count: big.NewInt(1),
+		pieces: map[uint64]*smartcontracts.ActivePieces{
+			0: {
+				Pieces:   []cid.Cid{rootCID},
+				PieceIds: []*big.Int{big.NewInt(int64(pieceID))},
+				HasMore:  false,
+			},
+		},
+	}
+
+	// Execute
+	result, err := repairProofSetCore(ctx, db, mock, proofSetID)
+
+	// Assert repair result
+	require.NoError(t, err)
+	require.Equal(t, 1, result.TotalOnChain)
+	require.Equal(t, 0, result.TotalInDB) // Was empty before repair
+	require.Equal(t, 1, result.TotalRepaired)
+	require.Equal(t, 0, result.TotalUnrepaired)
+	require.Len(t, result.RepairedEntries, 1)
+	require.Equal(t, rootCID.String(), result.RepairedEntries[0].RootCID)
+	require.Equal(t, pieceID, result.RepairedEntries[0].RootID)
+
+	// Assert database state: root now in pdp_proofset_roots
+	var roots []models.PDPProofsetRoot
+	require.NoError(t, db.Where("proofset_id = ?", proofSetID).Find(&roots).Error)
+	require.Len(t, roots, 1)
+	require.Equal(t, int64(pieceID), roots[0].RootID)
+
+	// Assert database state: entry removed from pdp_proofset_root_adds
+	var adds []models.PDPProofsetRootAdd
+	require.NoError(t, db.Where("proofset_id = ?", proofSetID).Find(&adds).Error)
+	require.Len(t, adds, 0)
+
+	// Assert database state: message_waits_eth marked as confirmed
+	var updatedMsg models.MessageWaitsEth
+	require.NoError(t, db.Where("signed_tx_hash = ?", "0x456").First(&updatedMsg).Error)
+	require.Equal(t, "confirmed", updatedMsg.TxStatus)
+	require.NotNil(t, updatedMsg.TxSuccess)
+	require.True(t, *updatedMsg.TxSuccess)
+}
+
+func TestRepairProofSetCore_UnrepairableRoot(t *testing.T) {
+	ctx := context.Background()
+	db := setupRepairTestDB(t)
+	proofSetID := uint64(1)
+
+	// Setup: Create message wait for proof set
+	msgWait := models.MessageWaitsEth{SignedTxHash: "0xabc", TxStatus: "confirmed"}
+	require.NoError(t, db.Create(&msgWait).Error)
+
+	// Setup: Create proof set
+	proofSet := models.PDPProofSet{ID: int64(proofSetID), CreateMessageHash: "0xabc", Service: "test"}
+	require.NoError(t, db.Create(&proofSet).Error)
+
+	// Setup: Root exists on-chain but NO metadata in pdp_proofset_root_adds
+	rootCID := testCID(t, "orphan-root")
+	pieceID := uint64(99)
+
+	mock := &mockActivePiecesProvider{
+		count: big.NewInt(1),
+		pieces: map[uint64]*smartcontracts.ActivePieces{
+			0: {
+				Pieces:   []cid.Cid{rootCID},
+				PieceIds: []*big.Int{big.NewInt(int64(pieceID))},
+				HasMore:  false,
+			},
+		},
+	}
+
+	// Execute
+	result, err := repairProofSetCore(ctx, db, mock, proofSetID)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, 1, result.TotalOnChain)
+	require.Equal(t, 0, result.TotalInDB)
+	require.Equal(t, 0, result.TotalRepaired)
+	require.Equal(t, 1, result.TotalUnrepaired)
+	require.Len(t, result.UnrepairedEntries, 1)
+	require.Equal(t, rootCID.String(), result.UnrepairedEntries[0].RootCID)
+	require.Contains(t, result.UnrepairedEntries[0].Reason, "metadata not found")
+}
+
+func TestRepairProofSetCore_Pagination(t *testing.T) {
+	ctx := context.Background()
+	db := setupRepairTestDB(t)
+	proofSetID := uint64(1)
+
+	// Setup: Create message wait for proof set
+	msgWait := models.MessageWaitsEth{SignedTxHash: "0x999", TxStatus: "confirmed"}
+	require.NoError(t, db.Create(&msgWait).Error)
+
+	// Setup: Create proof set
+	proofSet := models.PDPProofSet{ID: int64(proofSetID), CreateMessageHash: "0x999", Service: "test"}
+	require.NoError(t, db.Create(&proofSet).Error)
+
+	// Setup: 150 roots on-chain (requires pagination with limit=100)
+	rootCIDs := make([]cid.Cid, 150)
+	pieceIds := make([]*big.Int, 150)
+	for i := 0; i < 150; i++ {
+		rootCIDs[i] = testCID(t, fmt.Sprintf("root-%d", i))
+		pieceIds[i] = big.NewInt(int64(i))
+	}
+
+	// All roots also exist in DB (no repair needed, just testing pagination)
+	for i := 0; i < 150; i++ {
+		root := models.PDPProofsetRoot{
+			ProofsetID:     int64(proofSetID),
+			RootID:         int64(i),
+			SubrootOffset:  0,
+			Root:           rootCIDs[i].String(),
+			AddMessageHash: "0x999",
+			Subroot:        testCID(t, fmt.Sprintf("subroot-%d", i)).String(),
+			SubrootSize:    1024,
+		}
+		require.NoError(t, db.Create(&root).Error)
+	}
+
+	// Mock returns paginated results
+	mock := &mockActivePiecesProvider{
+		count: big.NewInt(150),
+		pieces: map[uint64]*smartcontracts.ActivePieces{
+			0: {
+				Pieces:   rootCIDs[:100],
+				PieceIds: pieceIds[:100],
+				HasMore:  true,
+			},
+			100: {
+				Pieces:   rootCIDs[100:],
+				PieceIds: pieceIds[100:],
+				HasMore:  false,
+			},
+		},
+	}
+
+	// Execute
+	result, err := repairProofSetCore(ctx, db, mock, proofSetID)
+
+	// Assert pagination worked correctly
+	require.NoError(t, err)
+	require.Equal(t, 150, result.TotalOnChain)
+	require.Equal(t, 150, result.TotalInDB)
+	require.Equal(t, 0, result.TotalRepaired)
+}
+
+func TestRepairProofSetCore_ProofSetNotFound(t *testing.T) {
+	ctx := context.Background()
+	db := setupRepairTestDB(t)
+
+	mock := &mockActivePiecesProvider{}
+
+	// Execute with non-existent proof set
+	result, err := repairProofSetCore(ctx, db, mock, 999)
+
+	// Assert
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestRepairProofSetCore_ChainError(t *testing.T) {
+	ctx := context.Background()
+	db := setupRepairTestDB(t)
+	proofSetID := uint64(1)
+
+	// Setup: Create message wait for proof set
+	msgWait := models.MessageWaitsEth{SignedTxHash: "0xdef", TxStatus: "confirmed"}
+	require.NoError(t, db.Create(&msgWait).Error)
+
+	// Setup: Create proof set
+	proofSet := models.PDPProofSet{ID: int64(proofSetID), CreateMessageHash: "0xdef", Service: "test"}
+	require.NoError(t, db.Create(&proofSet).Error)
+
+	mock := &mockActivePiecesProvider{
+		countErr: fmt.Errorf("chain connection failed"),
+	}
+
+	// Execute
+	result, err := repairProofSetCore(ctx, db, mock, proofSetID)
+
+	// Assert
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, err.Error(), "chain connection failed")
+}
+
+func TestRepairProofSetCore_MultipleSubroots(t *testing.T) {
+	ctx := context.Background()
+	db := setupRepairTestDB(t)
+	proofSetID := uint64(1)
+
+	// Setup: Create message wait
+	msgWait := models.MessageWaitsEth{SignedTxHash: "0x789", TxStatus: "pending"}
+	require.NoError(t, db.Create(&msgWait).Error)
+
+	// Setup: Create proof set
+	proofSet := models.PDPProofSet{ID: int64(proofSetID), CreateMessageHash: "0x789", Service: "test"}
+	require.NoError(t, db.Create(&proofSet).Error)
+
+	// Setup: One root with multiple subroots in pdp_proofset_root_adds
+	rootCID := testCID(t, "multi-subroot-root")
+	pieceID := uint64(50)
+	addMsgIndex := int64(0)
+
+	for i := 0; i < 3; i++ {
+		rootAdd := models.PDPProofsetRootAdd{
+			ProofsetID:      int64(proofSetID),
+			AddMessageHash:  "0x789",
+			SubrootOffset:   int64(i * 1024),
+			Root:            rootCID.String(),
+			AddMessageOK:    nil,
+			AddMessageIndex: &addMsgIndex,
+			Subroot:         testCID(t, fmt.Sprintf("subroot-%d", i)).String(),
+			SubrootSize:     1024,
+		}
+		require.NoError(t, db.Create(&rootAdd).Error)
+	}
+
+	mock := &mockActivePiecesProvider{
+		count: big.NewInt(1),
+		pieces: map[uint64]*smartcontracts.ActivePieces{
+			0: {
+				Pieces:   []cid.Cid{rootCID},
+				PieceIds: []*big.Int{big.NewInt(int64(pieceID))},
+				HasMore:  false,
+			},
+		},
+	}
+
+	// Execute
+	result, err := repairProofSetCore(ctx, db, mock, proofSetID)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, 1, result.TotalRepaired)
+	require.Equal(t, 3, result.RepairedEntries[0].Subroots)
+
+	// Assert all 3 subroots were created in pdp_proofset_roots
+	var roots []models.PDPProofsetRoot
+	require.NoError(t, db.Where("proofset_id = ? AND root_id = ?", proofSetID, pieceID).Find(&roots).Error)
+	require.Len(t, roots, 3)
+
+	// Assert MessageWaitsEth: single message hash updated (shared by all 3 subroots)
+	var updatedMsg models.MessageWaitsEth
+	require.NoError(t, db.Where("signed_tx_hash = ?", "0x789").First(&updatedMsg).Error)
+	require.Equal(t, "confirmed", updatedMsg.TxStatus)
+	require.NotNil(t, updatedMsg.TxSuccess)
+	require.True(t, *updatedMsg.TxSuccess)
+}
+
+func TestRepairProofSetCore_MixedResults(t *testing.T) {
+	ctx := context.Background()
+	db := setupRepairTestDB(t)
+	proofSetID := uint64(1)
+
+	// Setup: Create message waits
+	msgWait1 := models.MessageWaitsEth{SignedTxHash: "0xaaa", TxStatus: "pending"}
+	require.NoError(t, db.Create(&msgWait1).Error)
+	msgWait2 := models.MessageWaitsEth{SignedTxHash: "0xbbb", TxStatus: "confirmed"}
+	require.NoError(t, db.Create(&msgWait2).Error)
+
+	// Setup: Create proof set
+	proofSet := models.PDPProofSet{ID: int64(proofSetID), CreateMessageHash: "0xaaa", Service: "test"}
+	require.NoError(t, db.Create(&proofSet).Error)
+
+	// Setup: One repairable root, one unrepairable root, one existing root
+	repairableCID := testCID(t, "repairable-root")
+	unrepairableCID := testCID(t, "unrepairable-root")
+	existingCID := testCID(t, "existing-root")
+
+	// Add metadata for repairable root
+	addMsgIndex := int64(0)
+	rootAdd := models.PDPProofsetRootAdd{
+		ProofsetID:      int64(proofSetID),
+		AddMessageHash:  "0xaaa",
+		SubrootOffset:   0,
+		Root:            repairableCID.String(),
+		AddMessageOK:    nil,
+		AddMessageIndex: &addMsgIndex,
+		Subroot:         testCID(t, "repairable-subroot").String(),
+		SubrootSize:     1024,
+	}
+	require.NoError(t, db.Create(&rootAdd).Error)
+
+	// Add existing root to DB
+	existingRoot := models.PDPProofsetRoot{
+		ProofsetID:     int64(proofSetID),
+		RootID:         100,
+		SubrootOffset:  0,
+		Root:           existingCID.String(),
+		AddMessageHash: "0xbbb",
+		Subroot:        testCID(t, "existing-subroot").String(),
+		SubrootSize:    1024,
+	}
+	require.NoError(t, db.Create(&existingRoot).Error)
+
+	// Mock returns all three roots as active on-chain
+	mock := &mockActivePiecesProvider{
+		count: big.NewInt(3),
+		pieces: map[uint64]*smartcontracts.ActivePieces{
+			0: {
+				Pieces:   []cid.Cid{repairableCID, unrepairableCID, existingCID},
+				PieceIds: []*big.Int{big.NewInt(1), big.NewInt(2), big.NewInt(100)},
+				HasMore:  false,
+			},
+		},
+	}
+
+	// Execute
+	result, err := repairProofSetCore(ctx, db, mock, proofSetID)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, 3, result.TotalOnChain)
+	require.Equal(t, 1, result.TotalInDB) // Only existing root was in DB
+	require.Equal(t, 1, result.TotalRepaired)
+	require.Equal(t, 1, result.TotalUnrepaired)
+
+	// Verify repaired entry
+	require.Len(t, result.RepairedEntries, 1)
+	require.Equal(t, repairableCID.String(), result.RepairedEntries[0].RootCID)
+
+	// Verify unrepairable entry
+	require.Len(t, result.UnrepairedEntries, 1)
+	require.Equal(t, unrepairableCID.String(), result.UnrepairedEntries[0].RootCID)
+
+	// Assert MessageWaitsEth: pending message for repaired root is now confirmed
+	var updatedMsg models.MessageWaitsEth
+	require.NoError(t, db.Where("signed_tx_hash = ?", "0xaaa").First(&updatedMsg).Error)
+	require.Equal(t, "confirmed", updatedMsg.TxStatus)
+	require.NotNil(t, updatedMsg.TxSuccess)
+	require.True(t, *updatedMsg.TxSuccess)
+
+	// Assert MessageWaitsEth: already-confirmed message for existing root is unchanged
+	var unchangedMsg models.MessageWaitsEth
+	require.NoError(t, db.Where("signed_tx_hash = ?", "0xbbb").First(&unchangedMsg).Error)
+	require.Equal(t, "confirmed", unchangedMsg.TxStatus)
+	// TxSuccess should still be nil (wasn't touched by repair)
+	require.Nil(t, unchangedMsg.TxSuccess)
+}
+
+func TestRepairProofSetCore_NilAddMessageIndex(t *testing.T) {
+	ctx := context.Background()
+	db := setupRepairTestDB(t)
+	proofSetID := uint64(1)
+
+	// Setup: Create message wait
+	msgWait := models.MessageWaitsEth{SignedTxHash: "0xnil", TxStatus: "pending"}
+	require.NoError(t, db.Create(&msgWait).Error)
+
+	// Setup: Create proof set
+	proofSet := models.PDPProofSet{ID: int64(proofSetID), CreateMessageHash: "0xnil", Service: "test"}
+	require.NoError(t, db.Create(&proofSet).Error)
+
+	// Setup: Root add entry with nil AddMessageIndex
+	rootCID := testCID(t, "nil-index-root")
+	rootAdd := models.PDPProofsetRootAdd{
+		ProofsetID:      int64(proofSetID),
+		AddMessageHash:  "0xnil",
+		SubrootOffset:   0,
+		Root:            rootCID.String(),
+		AddMessageOK:    nil,
+		AddMessageIndex: nil, // Explicitly nil
+		Subroot:         testCID(t, "nil-index-subroot").String(),
+		SubrootSize:     1024,
+	}
+	require.NoError(t, db.Create(&rootAdd).Error)
+
+	mock := &mockActivePiecesProvider{
+		count: big.NewInt(1),
+		pieces: map[uint64]*smartcontracts.ActivePieces{
+			0: {
+				Pieces:   []cid.Cid{rootCID},
+				PieceIds: []*big.Int{big.NewInt(77)},
+				HasMore:  false,
+			},
+		},
+	}
+
+	// Execute - should not panic on nil AddMessageIndex
+	result, err := repairProofSetCore(ctx, db, mock, proofSetID)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, 1, result.TotalRepaired)
+
+	// Verify the root was created with AddMessageIndex = 0 (default)
+	var roots []models.PDPProofsetRoot
+	require.NoError(t, db.Where("proofset_id = ?", proofSetID).Find(&roots).Error)
+	require.Len(t, roots, 1)
+	require.Equal(t, int64(0), roots[0].AddMessageIndex)
+
+	// Assert MessageWaitsEth: message is updated despite nil AddMessageIndex
+	var updatedMsg models.MessageWaitsEth
+	require.NoError(t, db.Where("signed_tx_hash = ?", "0xnil").First(&updatedMsg).Error)
+	require.Equal(t, "confirmed", updatedMsg.TxStatus)
+	require.NotNil(t, updatedMsg.TxSuccess)
+	require.True(t, *updatedMsg.TxSuccess)
+}
+
+func TestRepairProofSetCore_MultipleMessageHashes(t *testing.T) {
+	ctx := context.Background()
+	db := setupRepairTestDB(t)
+	proofSetID := uint64(1)
+
+	// Setup: Create multiple message waits (all pending)
+	msgWait1 := models.MessageWaitsEth{SignedTxHash: "0xmsg1", TxStatus: "pending"}
+	require.NoError(t, db.Create(&msgWait1).Error)
+	msgWait2 := models.MessageWaitsEth{SignedTxHash: "0xmsg2", TxStatus: "pending"}
+	require.NoError(t, db.Create(&msgWait2).Error)
+	msgWait3 := models.MessageWaitsEth{SignedTxHash: "0xmsg3", TxStatus: "pending"}
+	require.NoError(t, db.Create(&msgWait3).Error)
+
+	// Setup: Create proof set
+	proofSet := models.PDPProofSet{ID: int64(proofSetID), CreateMessageHash: "0xmsg1", Service: "test"}
+	require.NoError(t, db.Create(&proofSet).Error)
+
+	// Setup: One root with multiple subroots, each using DIFFERENT message hashes
+	rootCID := testCID(t, "multi-msg-root")
+	pieceID := uint64(60)
+
+	// Create 3 subroots with different message hashes
+	messageHashes := []string{"0xmsg1", "0xmsg2", "0xmsg3"}
+	for i := 0; i < 3; i++ {
+		addMsgIndex := int64(0)
+		rootAdd := models.PDPProofsetRootAdd{
+			ProofsetID:      int64(proofSetID),
+			AddMessageHash:  messageHashes[i],
+			SubrootOffset:   int64(i * 1024),
+			Root:            rootCID.String(),
+			AddMessageOK:    nil,
+			AddMessageIndex: &addMsgIndex,
+			Subroot:         testCID(t, fmt.Sprintf("multi-msg-subroot-%d", i)).String(),
+			SubrootSize:     1024,
+		}
+		require.NoError(t, db.Create(&rootAdd).Error)
+	}
+
+	mock := &mockActivePiecesProvider{
+		count: big.NewInt(1),
+		pieces: map[uint64]*smartcontracts.ActivePieces{
+			0: {
+				Pieces:   []cid.Cid{rootCID},
+				PieceIds: []*big.Int{big.NewInt(int64(pieceID))},
+				HasMore:  false,
+			},
+		},
+	}
+
+	// Execute
+	result, err := repairProofSetCore(ctx, db, mock, proofSetID)
+
+	// Assert repair succeeded
+	require.NoError(t, err)
+	require.Equal(t, 1, result.TotalRepaired)
+	require.Equal(t, 3, result.RepairedEntries[0].Subroots)
+
+	// Assert all 3 different message hashes were marked as confirmed
+	for _, msgHash := range messageHashes {
+		var updatedMsg models.MessageWaitsEth
+		require.NoError(t, db.Where("signed_tx_hash = ?", msgHash).First(&updatedMsg).Error)
+		require.Equal(t, "confirmed", updatedMsg.TxStatus, "message %s should be confirmed", msgHash)
+		require.NotNil(t, updatedMsg.TxSuccess, "message %s should have TxSuccess set", msgHash)
+		require.True(t, *updatedMsg.TxSuccess, "message %s should have TxSuccess=true", msgHash)
+	}
+}
+
+func TestRepairProofSetCore_AlreadyConfirmedMessage(t *testing.T) {
+	ctx := context.Background()
+	db := setupRepairTestDB(t)
+	proofSetID := uint64(1)
+
+	// Setup: Create message wait that is ALREADY confirmed (not pending)
+	// This simulates a message that was confirmed through normal flow but root wasn't created
+	alreadyTrue := true
+	msgWait := models.MessageWaitsEth{
+		SignedTxHash: "0xalready",
+		TxStatus:     "confirmed", // Already confirmed
+		TxSuccess:    &alreadyTrue,
+	}
+	require.NoError(t, db.Create(&msgWait).Error)
+
+	// Setup: Create proof set
+	proofSet := models.PDPProofSet{ID: int64(proofSetID), CreateMessageHash: "0xalready", Service: "test"}
+	require.NoError(t, db.Create(&proofSet).Error)
+
+	// Setup: Root add entry referencing the already-confirmed message
+	rootCID := testCID(t, "already-confirmed-root")
+	addMsgIndex := int64(0)
+	rootAdd := models.PDPProofsetRootAdd{
+		ProofsetID:      int64(proofSetID),
+		AddMessageHash:  "0xalready",
+		SubrootOffset:   0,
+		Root:            rootCID.String(),
+		AddMessageOK:    nil,
+		AddMessageIndex: &addMsgIndex,
+		Subroot:         testCID(t, "already-confirmed-subroot").String(),
+		SubrootSize:     1024,
+	}
+	require.NoError(t, db.Create(&rootAdd).Error)
+
+	mock := &mockActivePiecesProvider{
+		count: big.NewInt(1),
+		pieces: map[uint64]*smartcontracts.ActivePieces{
+			0: {
+				Pieces:   []cid.Cid{rootCID},
+				PieceIds: []*big.Int{big.NewInt(88)},
+				HasMore:  false,
+			},
+		},
+	}
+
+	// Execute
+	result, err := repairProofSetCore(ctx, db, mock, proofSetID)
+
+	// Assert repair succeeded
+	require.NoError(t, err)
+	require.Equal(t, 1, result.TotalRepaired)
+
+	// Assert the root was created
+	var roots []models.PDPProofsetRoot
+	require.NoError(t, db.Where("proofset_id = ?", proofSetID).Find(&roots).Error)
+	require.Len(t, roots, 1)
+
+	// Assert MessageWaitsEth: already-confirmed message was NOT modified
+	// The WHERE clause `tx_status = "pending"` should prevent updates to confirmed messages
+	var unchangedMsg models.MessageWaitsEth
+	require.NoError(t, db.Where("signed_tx_hash = ?", "0xalready").First(&unchangedMsg).Error)
+	require.Equal(t, "confirmed", unchangedMsg.TxStatus)
+	// TxSuccess should still be true (the original value, not touched by repair)
+	require.NotNil(t, unchangedMsg.TxSuccess)
+	require.True(t, *unchangedMsg.TxSuccess)
+}
+
+func TestGetAllActivePiecesCore_EmptyResult(t *testing.T) {
+	ctx := context.Background()
+
+	mock := &mockActivePiecesProvider{
+		count: big.NewInt(0),
+		pieces: map[uint64]*smartcontracts.ActivePieces{
+			0: {
+				Pieces:   []cid.Cid{},
+				PieceIds: []*big.Int{},
+				HasMore:  false,
+			},
+		},
+	}
+
+	result, err := getAllActivePiecesCore(ctx, mock, 1)
+
+	require.NoError(t, err)
+	require.Empty(t, result)
+}
+
+func TestGetAllActivePiecesCore_PaginationError(t *testing.T) {
+	ctx := context.Background()
+
+	// Create valid first page data
+	firstPageCIDs := make([]cid.Cid, 100)
+	firstPageIDs := make([]*big.Int, 100)
+	for i := 0; i < 100; i++ {
+		firstPageCIDs[i] = testCID(t, fmt.Sprintf("page1-root-%d", i))
+		firstPageIDs[i] = big.NewInt(int64(i))
+	}
+
+	mock := &mockActivePiecesProvider{
+		count: big.NewInt(200),
+		pieces: map[uint64]*smartcontracts.ActivePieces{
+			0: {
+				Pieces:   firstPageCIDs,
+				PieceIds: firstPageIDs,
+				HasMore:  true,
+			},
+			// Second page not in map - will return empty ActivePieces with HasMore=false
+		},
+	}
+
+	// First page succeeds, second page returns empty (which gracefully stops pagination)
+	result, err := getAllActivePiecesCore(ctx, mock, 1)
+
+	require.NoError(t, err)
+	// Should have returned what was fetched from first page
+	require.Len(t, result, 100)
+}
+
+func TestGetAllActivePiecesCore_GetPiecesError(t *testing.T) {
+	ctx := context.Background()
+
+	mock := &mockActivePiecesProvider{
+		count:     big.NewInt(100),
+		piecesErr: fmt.Errorf("RPC connection failed"),
+	}
+
+	result, err := getAllActivePiecesCore(ctx, mock, 1)
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, err.Error(), "RPC connection failed")
+}

--- a/pkg/pdp/smartcontracts/verifier.go
+++ b/pkg/pdp/smartcontracts/verifier.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
 	"golang.org/x/xerrors"
 
@@ -27,6 +28,8 @@ type Verifier interface {
 	FindPieceIds(ctx context.Context, setId *big.Int, leafIndexs []*big.Int) ([]bindings.IPDPTypesPieceIdAndOffset, error)
 	CalculateProofFee(ctx context.Context, setId *big.Int) (*big.Int, error)
 	MaxPieceSizeLog2(ctx context.Context) (*big.Int, error)
+	GetActivePieces(ctx context.Context, setID *big.Int, offset *big.Int, limit *big.Int) (*ActivePieces, error)
+	GetActivePieceCount(ctx context.Context, setId *big.Int) (*big.Int, error)
 
 	// not part of contract code, added for convience in testing and usage
 	Address() common.Address
@@ -186,4 +189,45 @@ func (v *verifierContract) GetPieceIdsFromReceipt(receipt *types.Receipt) ([]uin
 	}
 
 	return nil, fmt.Errorf("unexpected error in GetPieceIdsFromReceipt")
+}
+
+type ActivePieces struct {
+	Pieces   []cid.Cid
+	PieceIds []*big.Int
+	HasMore  bool
+}
+
+func (v *verifierContract) GetActivePieces(
+	ctx context.Context,
+	setID *big.Int,
+	offset *big.Int,
+	limit *big.Int,
+) (*ActivePieces, error) {
+	res, err := v.verifier.GetActivePieces(&bind.CallOpts{Context: ctx}, setID, offset, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	pieces := make([]cid.Cid, len(res.Pieces))
+	for i, piece := range res.Pieces {
+		parsedCid, err := cid.Cast(piece.Data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse piece CID at index %d: %w", i, err)
+		}
+		pieces[i] = parsedCid
+	}
+
+	out := &ActivePieces{
+		Pieces:   pieces,
+		PieceIds: res.PieceIds,
+		HasMore:  res.HasMore,
+	}
+
+	log.Debugw("cached GetActivePieces result", "setID", setID, "offset", offset, "limit", limit)
+
+	return out, nil
+}
+
+func (v *verifierContract) GetActivePieceCount(ctx context.Context, setId *big.Int) (*big.Int, error) {
+	return v.verifier.GetActivePieceCount(&bind.CallOpts{Context: ctx}, setId)
 }

--- a/pkg/pdp/tasks/watch_addroot.go
+++ b/pkg/pdp/tasks/watch_addroot.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"golang.org/x/xerrors"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	chainyypes "github.com/filecoin-project/lotus/chain/types"
 
@@ -139,6 +140,7 @@ func insertRootIds(
 
 			rootId := rootIds[*entry.AddMessageIndex]
 			// Insert into pdp_proofset_roots
+			// Use ON CONFLICT DO NOTHING to handle race conditions with repair command
 			root := models.PDPProofsetRoot{
 				ProofsetID:      entry.ProofsetID,
 				Root:            entry.Root,
@@ -150,7 +152,7 @@ func insertRootIds(
 				AddMessageHash:  entry.AddMessageHash,
 				AddMessageIndex: *entry.AddMessageIndex,
 			}
-			err := tx.Create(&root).Error
+			err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&root).Error
 			if err != nil {
 				return fmt.Errorf("failed to insert into pdp_proofset_roots: %w", err)
 			}

--- a/pkg/pdp/types/api.go
+++ b/pkg/pdp/types/api.go
@@ -196,12 +196,40 @@ const (
 	// as an enum, so it's value is 0
 )
 
+// RepairResult contains the result of a proof set repair operation
+type RepairResult struct {
+	// State comparison
+	TotalOnChain int // Active pieces on chain
+	TotalInDB    int // Roots in pdp_proofset_roots
+
+	// Repair results
+	TotalRepaired     int
+	TotalUnrepaired   int
+	RepairedEntries   []RepairedEntry
+	UnrepairedEntries []UnrepairedEntry
+}
+
+// RepairedEntry represents a successfully repaired root
+type RepairedEntry struct {
+	RootCID  string
+	RootID   uint64
+	Subroots int
+}
+
+// UnrepairedEntry represents a root that could not be repaired
+type UnrepairedEntry struct {
+	RootCID string
+	RootID  uint64
+	Reason  string
+}
+
 type ProofSetAPI interface {
 	CreateProofSet(ctx context.Context) (common.Hash, error)
 	GetProofSetStatus(ctx context.Context, txHash common.Hash) (*ProofSetStatus, error)
 	GetProofSet(ctx context.Context, proofSetID uint64) (*ProofSet, error)
 	AddRoots(ctx context.Context, proofSetID uint64, roots []RootAdd) (common.Hash, error)
 	RemoveRoot(ctx context.Context, proofSetID uint64, rootID uint64) (common.Hash, error)
+	RepairProofSet(ctx context.Context, proofSetID uint64) (*RepairResult, error)
 }
 
 type Range struct {


### PR DESCRIPTION


  When Lotus goes offline and loses state (due to garbage collection), Piri
  can get stuck because WatcherEth cannot retrieve transaction receipts.
  This leaves pdp_proofset_root_adds entries stuck and pdp_proofset_roots
  unpopulated, causing the proving pipeline to fail.

  The repair command:
  - Fetches active pieces from the chain via GetActivePieces (with pagination)
  - Compares chain state with pdp_proofset_roots to find gaps
  - Repairs gaps using metadata from pdp_proofset_root_adds
  - Marks associated message_waits_eth entries as confirmed
  - Reports unrepairable roots (missing metadata)

  Implementation:
  - CLI: `piri client pdp proofset repair --proofset-id <ID>`
  - HTTP: POST /pdp/proof-sets/:proofSetID/repair
  - Service: repairProofSetCore with extracted dependencies for testability

  Also:
  - Add ON CONFLICT DO NOTHING to both repair and WatcherRootAdd for idempotent inserts (handles race conditions)
  - Add comprehensive unit tests with 14 test cases covering repair logic, pagination, error handling, and MessageWaitsEth updates