### PR TITLE
fix: flatfs sharding for blobstore keys

### DIFF
--- a/pkg/aws/s3store_test.go
+++ b/pkg/aws/s3store_test.go
@@ -16,8 +16,6 @@ import (
 	paws "github.com/storacha/piri/pkg/aws"
 	piritutil "github.com/storacha/piri/pkg/internal/testutil"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/modules/minio"
 )
 
 func TestS3StoreReplace(t *testing.T) {
@@ -32,8 +30,8 @@ func TestS3StoreReplace(t *testing.T) {
 		t.SkipNow()
 	}
 
-	endpoint := createS3(t)
-	client := newS3Client(t, endpoint)
+	endpoint := piritutil.StartMinioContainer(t)
+	client := newS3Client(t, testutil.Must(url.Parse("http://"+endpoint))(t))
 
 	bucketName := hex.EncodeToString(testutil.RandomBytes(t, 16))
 	createBucket(t, client, bucketName)
@@ -63,17 +61,6 @@ func TestS3StoreReplace(t *testing.T) {
 		err := st.Replace(t.Context(), key, nil, 32, bytes.NewReader(first))
 		require.NoError(t, err)
 	})
-}
-
-func createS3(t *testing.T) *url.URL {
-	container, err := minio.Run(t.Context(), "minio/minio:latest")
-	testcontainers.CleanupContainer(t, container)
-	require.NoError(t, err)
-
-	addr, err := container.ConnectionString(t.Context())
-	require.NoError(t, err)
-
-	return testutil.Must(url.Parse("http://" + addr))(t)
 }
 
 func newS3Client(t *testing.T, endpoint *url.URL) *s3.Client {

--- a/pkg/internal/testutil/minio.go
+++ b/pkg/internal/testutil/minio.go
@@ -1,0 +1,21 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/minio"
+)
+
+func StartMinioContainer(t *testing.T) string {
+	container, err := minio.Run(t.Context(), "minio/minio:latest")
+	testcontainers.CleanupContainer(t, container)
+	require.NoError(t, err)
+
+	endpoint, err := container.ConnectionString(t.Context())
+	require.NoError(t, err)
+
+	t.Logf("Minio listening on: http://%s", endpoint)
+	return endpoint
+}

--- a/pkg/store/blobstore/key_encoder.go
+++ b/pkg/store/blobstore/key_encoder.go
@@ -1,9 +1,12 @@
 package blobstore
 
 import (
+	"path/filepath"
+
 	"github.com/multiformats/go-multibase"
 	"github.com/multiformats/go-multihash"
 	"github.com/storacha/go-libstoracha/digestutil"
+	"github.com/storacha/piri/pkg/store/objectstore/flatfs"
 )
 
 // KeyEncoder defines how to encode blob keys for a specific backend.
@@ -12,7 +15,7 @@ type KeyEncoder interface {
 }
 
 // Base32KeyEncoder encodes keys as base32 (S3/MinIO compatible with IPFS boxo).
-// This is the default encoder for S3 and flatfs backends.
+// This is the default encoder for flatfs backends.
 type Base32KeyEncoder struct{}
 
 func (Base32KeyEncoder) EncodeKey(digest multihash.Multihash) string {
@@ -28,4 +31,21 @@ type PlainKeyEncoder struct{}
 
 func (PlainKeyEncoder) EncodeKey(digest multihash.Multihash) string {
 	return digestutil.Format(digest)
+}
+
+// Base32FlatFSKeyEncoder is a [Base32KeyEncoder] that also adds a sharding
+// directory prefix and ".data" suffix, making it compatible with FlatFS
+// NextToLast(2) sharding.
+type Base32FlatFSKeyEncoder struct {
+	shard flatfs.ShardFunc
+}
+
+func NewBase32FlatFSKeyEncoder() *Base32FlatFSKeyEncoder {
+	return &Base32FlatFSKeyEncoder{shard: flatfs.NextToLast(2).Func()}
+}
+
+func (f *Base32FlatFSKeyEncoder) EncodeKey(digest multihash.Multihash) string {
+	b32 := Base32KeyEncoder{}.EncodeKey(digest)
+	dir := f.shard(b32)
+	return filepath.Join(dir, b32+".data")
 }

--- a/pkg/store/blobstore/store.go
+++ b/pkg/store/blobstore/store.go
@@ -27,7 +27,7 @@ type Store struct {
 func NewS3Store(backend *minio_store.Store) *Store {
 	return &Store{
 		backend: backend,
-		encoder: Base32KeyEncoder{},
+		encoder: NewBase32FlatFSKeyEncoder(),
 	}
 }
 

--- a/pkg/store/blobstore/store_test.go
+++ b/pkg/store/blobstore/store_test.go
@@ -6,17 +6,23 @@ import (
 	"io"
 	"os"
 	"path"
+	"runtime"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/sync"
 	"github.com/multiformats/go-multihash"
 	"github.com/storacha/go-libstoracha/testutil"
 	"github.com/stretchr/testify/require"
 
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	piritestutil "github.com/storacha/piri/pkg/internal/testutil"
 	"github.com/storacha/piri/pkg/store"
 	"github.com/storacha/piri/pkg/store/objectstore/flatfs"
+	minio_store "github.com/storacha/piri/pkg/store/objectstore/minio"
 )
 
 func TestBlobstore(t *testing.T) {
@@ -28,58 +34,74 @@ func TestBlobstore(t *testing.T) {
 	require.NoError(t, err)
 
 	impls := map[string]Blobstore{
-		"MemoryStore": NewDatastoreStore(sync.MutexWrap(datastore.NewMapDatastore())),
-		"Store":       NewFlatfsStore(testutil.Must(flatfs.New(flatfsDir, flatfs.NextToLast(2), false))(t)),
+		"memory": NewDatastoreStore(sync.MutexWrap(datastore.NewMapDatastore())),
+		"flatfs": NewFlatfsStore(testutil.Must(flatfs.New(flatfsDir, flatfs.NextToLast(2), false))(t)),
+	}
+
+	if piritestutil.IsDockerAvailable(t) {
+		endpoint := piritestutil.StartMinioContainer(t)
+		bucket := uuid.NewString()
+		s3store, err := minio_store.New(endpoint, bucket, minio.Options{
+			Creds:  credentials.NewStaticV4("minioadmin", "minioadmin", ""),
+			Secure: false,
+		})
+		require.NoError(t, err)
+		impls["s3"] = NewS3Store(s3store)
+	} else if piritestutil.IsRunningInCI(t) && runtime.GOOS == "linux" {
+		// This test expects docker to be running in linux CI environments and fails if it's not
+		t.Fatalf("docker is expected in CI linux testing environments, but wasn't found")
 	}
 
 	for k, s := range impls {
-		t.Run("roundtrip "+k, func(t *testing.T) {
-			data := testutil.RandomBytes(t, 10)
-			digest := testutil.Must(multihash.Sum(data, multihash.SHA2_256, -1))(t)
+		t.Run(k, func(t *testing.T) {
+			t.Run("roundtrip", func(t *testing.T) {
+				data := testutil.RandomBytes(t, 10)
+				digest := testutil.Must(multihash.Sum(data, multihash.SHA2_256, -1))(t)
 
-			err := s.Put(t.Context(), digest, uint64(len(data)), bytes.NewBuffer(data))
-			require.NoError(t, err)
+				err := s.Put(t.Context(), digest, uint64(len(data)), bytes.NewBuffer(data))
+				require.NoError(t, err)
 
-			obj, err := s.Get(t.Context(), digest)
-			require.NoError(t, err)
-			require.Equal(t, obj.Size(), int64(len(data)))
-			require.Equal(t, data, testutil.Must(io.ReadAll(obj.Body()))(t))
-		})
+				obj, err := s.Get(t.Context(), digest)
+				require.NoError(t, err)
+				require.Equal(t, obj.Size(), int64(len(data)))
+				require.Equal(t, data, testutil.Must(io.ReadAll(obj.Body()))(t))
+			})
 
-		t.Run("not found "+k, func(t *testing.T) {
-			data := testutil.RandomBytes(t, 10)
-			digest := testutil.Must(multihash.Sum(data, multihash.SHA2_256, -1))(t)
+			t.Run("not found", func(t *testing.T) {
+				data := testutil.RandomBytes(t, 10)
+				digest := testutil.Must(multihash.Sum(data, multihash.SHA2_256, -1))(t)
 
-			obj, err := s.Get(t.Context(), digest)
-			require.Error(t, err)
-			require.Equal(t, store.ErrNotFound, err)
-			require.Nil(t, obj)
-		})
+				obj, err := s.Get(t.Context(), digest)
+				require.Error(t, err)
+				require.Equal(t, store.ErrNotFound, err)
+				require.Nil(t, obj)
+			})
 
-		t.Run("delete "+k, func(t *testing.T) {
-			data := testutil.RandomBytes(t, 10)
-			digest := testutil.Must(multihash.Sum(data, multihash.SHA2_256, -1))(t)
+			t.Run("delete", func(t *testing.T) {
+				data := testutil.RandomBytes(t, 10)
+				digest := testutil.Must(multihash.Sum(data, multihash.SHA2_256, -1))(t)
 
-			err := s.Put(t.Context(), digest, uint64(len(data)), bytes.NewBuffer(data))
-			require.NoError(t, err)
+				err := s.Put(t.Context(), digest, uint64(len(data)), bytes.NewBuffer(data))
+				require.NoError(t, err)
 
-			err = s.Delete(t.Context(), digest)
-			require.NoError(t, err)
+				err = s.Delete(t.Context(), digest)
+				require.NoError(t, err)
 
-			_, err = s.Get(t.Context(), digest)
-			require.Equal(t, store.ErrNotFound, err)
-		})
+				_, err = s.Get(t.Context(), digest)
+				require.Equal(t, store.ErrNotFound, err)
+			})
 
-		t.Run("range not satisfiable "+k, func(t *testing.T) {
-			data := testutil.RandomBytes(t, 10)
-			digest := testutil.Must(multihash.Sum(data, multihash.SHA2_256, -1))(t)
+			t.Run("range not satisfiable", func(t *testing.T) {
+				data := testutil.RandomBytes(t, 10)
+				digest := testutil.Must(multihash.Sum(data, multihash.SHA2_256, -1))(t)
 
-			err := s.Put(t.Context(), digest, uint64(len(data)), bytes.NewReader(data))
-			require.NoError(t, err)
+				err := s.Put(t.Context(), digest, uint64(len(data)), bytes.NewReader(data))
+				require.NoError(t, err)
 
-			end := uint64(15)
-			_, err = s.Get(t.Context(), digest, WithRange(5, &end))
-			require.ErrorIs(t, err, NewRangeNotSatisfiableError(Range{Start: 5, End: &end}))
+				end := uint64(15)
+				_, err = s.Get(t.Context(), digest, WithRange(5, &end))
+				require.ErrorIs(t, err, NewRangeNotSatisfiableError(Range{Start: 5, End: &end}))
+			})
 		})
 	}
 }

--- a/pkg/store/objectstore/leveldb/leveldb.go
+++ b/pkg/store/objectstore/leveldb/leveldb.go
@@ -82,7 +82,7 @@ func (s *leveldbStore) Get(ctx context.Context, key string, opts ...objectstore.
 
 	rangedData := data[start:end]
 	return &leveldbObject{
-		size: int64(len(rangedData)),
+		size: int64(len(data)),
 		body: io.NopCloser(bytes.NewReader(rangedData)),
 	}, nil
 }

--- a/pkg/store/objectstore/memory/memory.go
+++ b/pkg/store/objectstore/memory/memory.go
@@ -81,7 +81,7 @@ func (s *memoryStore) Get(ctx context.Context, key string, opts ...objectstore.G
 
 	rangedData := data[start:end]
 	return &memoryObject{
-		size: int64(len(rangedData)),
+		size: int64(len(data)),
 		body: io.NopCloser(bytes.NewReader(rangedData)),
 	}, nil
 }

--- a/pkg/store/objectstore/minio/minio.go
+++ b/pkg/store/objectstore/minio/minio.go
@@ -104,9 +104,30 @@ func (s *Store) Get(ctx context.Context, key string, opts ...objectstore.GetOpti
 	config.ProcessOptions(opts)
 	log.Debugw("getting object", "bucket", s.bucket, "key", key, "options", config)
 
+	isRangeReq := config.Range().Start > 0 || config.Range().End != nil
+
+	// For range requests, we cannot rely on Stat() due to a known issue in minio-go
+	// where calling Stat() interferes with range requests and causes the entire file to be returned
+	statObj, err := s.client.StatObject(ctx, s.bucket, key, minio.StatObjectOptions{})
+	if err != nil {
+		var merr minio.ErrorResponse
+		if errors.As(err, &merr) {
+			if merr.Code == minio.NoSuchKey {
+				return nil, objectstore.ErrNotExist
+			}
+		}
+		log.Errorw("get object stat failed", "bucket", s.bucket, "key", key, "error", err)
+		return nil, fmt.Errorf("get object with key %s: %w", key, err)
+	}
+	size := statObj.Size
+
 	miOpts := minio.GetObjectOptions{}
 	// Check if a range is specified
-	if config.Range().Start != 0 || config.Range().End != nil {
+	if isRangeReq {
+		if !rangeSatisfiable(config.Range().Start, config.Range().End, uint64(size)) {
+			return nil, objectstore.ErrRangeNotSatisfiable{Range: config.Range()}
+		}
+
 		rStart := int64(config.Range().Start)
 		var rEnd int64
 
@@ -127,42 +148,17 @@ func (s *Store) Get(ctx context.Context, key string, opts ...objectstore.GetOpti
 	}
 	obj, err := s.client.GetObject(ctx, s.bucket, key, miOpts)
 	if err != nil {
-		log.Errorw("get object failed", "bucket", s.bucket, "key", key, "error", err)
-		return nil, fmt.Errorf("get object with key %s: %w", key, err)
-	}
-
-	// For range requests, we cannot rely on Stat() due to a known issue in minio-go
-	// where calling Stat() interferes with range requests and causes the entire file to be returned
-	var size int64
-
-	statObj, err := s.client.StatObject(ctx, s.bucket, key, minio.StatObjectOptions{})
-	if err != nil {
 		var merr minio.ErrorResponse
 		if errors.As(err, &merr) {
 			if merr.Code == minio.NoSuchKey {
 				return nil, objectstore.ErrNotExist
 			}
 		}
-		log.Errorw("get object stat failed", "bucket", s.bucket, "key", key, "error", err)
+		log.Errorw("get object failed", "bucket", s.bucket, "key", key, "error", err)
 		return nil, fmt.Errorf("get object with key %s: %w", key, err)
 	}
-	size = statObj.Size
-	log.Debugw("got object", "bucket", s.bucket, "key", key, "size", size, "duration", time.Since(start), "options", config)
 
-	if config.Range().Start != 0 || config.Range().End != nil {
-		// For range requests, we cannot call Stat() as it breaks the range functionality, returning the entire object size
-		// instead of the ranged-size.
-		// Calculate the expected size based on the range parameters
-		if config.Range().End != nil {
-			// Size is end - start + 1 (since end is inclusive)
-			size = int64(*config.Range().End - config.Range().Start + 1)
-		} else {
-			// For open-ended ranges (start to EOF), we need to get the full object size
-			// We'll do a HEAD request separately to avoid interfering with the range request
-			size = statObj.Size - int64(config.Range().Start)
-		}
-		log.Debugw("got object with range", "bucket", s.bucket, "key", key, "range_size", size, "duration", time.Since(start), "options", config)
-	}
+	log.Debugw("got object", "bucket", s.bucket, "key", key, "size", size, "duration", time.Since(start), "options", config)
 
 	return &MinioObject{
 		object: obj,
@@ -207,4 +203,21 @@ func (s *Store) ListPrefix(ctx context.Context, prefix string) iter.Seq2[string,
 			}
 		}
 	}
+}
+
+// rangeSatisfiable determines if the provided start/end byte range is
+// valid given the total size of the blob.
+func rangeSatisfiable(start uint64, end *uint64, size uint64) bool {
+	if size > 0 && start >= size {
+		return false
+	}
+	if end != nil {
+		if start > *end {
+			return false
+		}
+		if *end >= size {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/store/objectstore/minio/minio_bench_test.go
+++ b/pkg/store/objectstore/minio/minio_bench_test.go
@@ -19,7 +19,7 @@ import (
 var benchResult interface{}
 
 func BenchmarkPut(b *testing.B) {
-	if runtime.GOOS == "darwin" {
+	if os.Getenv("CI") != "" && runtime.GOOS == "darwin" {
 		fmt.Println("Skipping darwin tests, testcontainers not supported in CI")
 		os.Exit(0)
 	}
@@ -55,7 +55,7 @@ func BenchmarkPut(b *testing.B) {
 }
 
 func BenchmarkGet(b *testing.B) {
-	if runtime.GOOS == "darwin" {
+	if os.Getenv("CI") != "" && runtime.GOOS == "darwin" {
 		fmt.Println("Skipping darwin tests, testcontainers not supported in CI")
 		os.Exit(0)
 	}
@@ -111,7 +111,7 @@ func BenchmarkGet(b *testing.B) {
 }
 
 func BenchmarkGetRange(b *testing.B) {
-	if runtime.GOOS == "darwin" {
+	if os.Getenv("CI") != "" && runtime.GOOS == "darwin" {
 		fmt.Println("Skipping darwin tests, testcontainers not supported in CI")
 		os.Exit(0)
 	}
@@ -173,7 +173,7 @@ func BenchmarkGetRange(b *testing.B) {
 }
 
 func BenchmarkConcurrentPut(b *testing.B) {
-	if runtime.GOOS == "darwin" {
+	if os.Getenv("CI") != "" && runtime.GOOS == "darwin" {
 		fmt.Println("Skipping darwin tests, testcontainers not supported in CI")
 		os.Exit(0)
 	}
@@ -222,7 +222,7 @@ func BenchmarkConcurrentPut(b *testing.B) {
 }
 
 func BenchmarkConcurrentGet(b *testing.B) {
-	if runtime.GOOS == "darwin" {
+	if os.Getenv("CI") != "" && runtime.GOOS == "darwin" {
 		fmt.Println("Skipping darwin tests, testcontainers not supported in CI")
 		os.Exit(0)
 	}

--- a/pkg/store/objectstore/minio/minio_test.go
+++ b/pkg/store/objectstore/minio/minio_test.go
@@ -13,8 +13,7 @@ import (
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
+	tcminio "github.com/testcontainers/testcontainers-go/modules/minio"
 )
 
 func TestBucketCreation(t *testing.T) {
@@ -46,43 +45,22 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	if runtime.GOOS == "darwin" {
+	if os.Getenv("CI") != "" && runtime.GOOS == "darwin" {
 		fmt.Println("Skipping darwin tests, testcontainers not supported in CI")
 		os.Exit(0)
 	}
 	logging.SetDebugLogging()
 	ctx := context.Background()
 
-	req := testcontainers.ContainerRequest{
-		Image:        "minio/minio:latest",
-		ExposedPorts: []string{"9000/tcp"},
-		Env: map[string]string{
-			"MINIO_ACCESS_KEY": "minioadmin",
-			"MINIO_SECRET_KEY": "minioadmin",
-		},
-		Cmd:        []string{"server", "/data"},
-		WaitingFor: wait.ForHTTP("/minio/health/live").WithPort("9000"),
-	}
-
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
+	container, err := tcminio.Run(ctx, "minio/minio:latest")
 	if err != nil {
 		panic(fmt.Sprintf("Failed to start MinIO container: %v", err))
 	}
 
-	host, err := container.Host(ctx)
+	minioEndpoint, err = container.ConnectionString(ctx)
 	if err != nil {
-		panic(fmt.Sprintf("Failed to get container host: %v", err))
+		panic(fmt.Sprintf("Failed to get container endpoint: %v", err))
 	}
-
-	port, err := container.MappedPort(ctx, "9000")
-	if err != nil {
-		panic(fmt.Sprintf("Failed to get container port: %v", err))
-	}
-
-	minioEndpoint = fmt.Sprintf("%s:%s", host, port.Port())
 
 	code := m.Run()
 

--- a/pkg/store/objectstore/store_test.go
+++ b/pkg/store/objectstore/store_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -13,13 +12,11 @@ import (
 	"testing"
 	"time"
 
-	logging "github.com/ipfs/go-log/v2"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
 
+	"github.com/storacha/piri/pkg/internal/testutil"
 	"github.com/storacha/piri/pkg/store/objectstore"
 	"github.com/storacha/piri/pkg/store/objectstore/flatfs"
 	"github.com/storacha/piri/pkg/store/objectstore/leveldb"
@@ -54,344 +51,281 @@ func makeStore(t *testing.T, k StoreKind) objectstore.Store {
 	panic("unknown store kind")
 }
 
-func TestPutOperations(t *testing.T) {
-	tests := []struct {
-		name      string
-		key       string
-		data      []byte
-		size      uint64
-		expectErr bool
-		skip      []StoreKind
-	}{
-		{
-			name: "successful put",
-			key:  "test-key",
-			data: []byte("hello world"),
-			size: 11,
-		},
-		{
-			name: "put with empty data",
-			key:  "empty-key",
-			data: []byte{},
-			size: 0,
-		},
-		{
-			name: "put with large data",
-			key:  "large-key",
-			data: bytes.Repeat([]byte("a"), 1024*1024), // 1MB
-			size: 1024 * 1024,
-		},
-		{
-			name:      "put with size mismatch",
-			key:       "mismatch-key",
-			data:      []byte("hello"),
-			size:      10, // Wrong size
-			expectErr: true,
-		},
-		{
-			name: "put with special characters in key",
-			key:  "special/key/with-dashes_and.dots",
-			data: []byte("special data"),
-			size: 12,
-			skip: []StoreKind{
-				FlatFS, // no slashes allowed in flatfs
-			},
-		},
-	}
+func TestObjectStore(t *testing.T) {
+	// logging.SetDebugLogging()
 
 	for _, k := range storeKinds {
-		for _, tt := range tests {
-			t.Run(fmt.Sprintf("%s_%s", k, tt.name), func(t *testing.T) {
-				if slices.Contains(tt.skip, k) {
-					t.SkipNow()
+		t.Run(string(k), func(t *testing.T) {
+			store := makeStore(t, k)
+
+			t.Run("put operations", func(t *testing.T) {
+				tests := []struct {
+					name      string
+					key       string
+					data      []byte
+					size      uint64
+					expectErr bool
+					skip      []StoreKind
+				}{
+					{
+						name: "successful put",
+						key:  "test-key",
+						data: []byte("hello world"),
+						size: 11,
+					},
+					{
+						name: "put with empty data",
+						key:  "empty-key",
+						data: []byte{},
+						size: 0,
+					},
+					{
+						name: "put with large data",
+						key:  "large-key",
+						data: bytes.Repeat([]byte("a"), 1024*1024), // 1MB
+						size: 1024 * 1024,
+					},
+					{
+						name:      "put with size mismatch",
+						key:       "mismatch-key",
+						data:      []byte("hello"),
+						size:      10, // Wrong size
+						expectErr: true,
+					},
+					{
+						name: "put with special characters in key",
+						key:  "special/key/with-dashes_and.dots",
+						data: []byte("special data"),
+						size: 12,
+						skip: []StoreKind{
+							FlatFS, // no slashes allowed in flatfs
+						},
+					},
 				}
-				ctx := context.Background()
-				store := makeStore(t, k)
 
-				err := store.Put(ctx, tt.key, tt.size, bytes.NewReader(tt.data))
+				for _, tt := range tests {
+					t.Run(tt.name, func(t *testing.T) {
+						if slices.Contains(tt.skip, k) {
+							t.SkipNow()
+						}
+						ctx := t.Context()
 
-				if tt.expectErr {
-					require.Error(t, err)
-				} else {
-					require.NoError(t, err)
+						err := store.Put(ctx, tt.key, tt.size, bytes.NewReader(tt.data))
 
-					// Verify the object was stored correctly
-					obj, err := store.Get(ctx, tt.key)
-					require.NoError(t, err)
-					defer obj.Body().Close()
+						if tt.expectErr {
+							require.Error(t, err)
+						} else {
+							require.NoError(t, err)
 
-					content, err := io.ReadAll(obj.Body())
-					require.NoError(t, err)
-					require.Equal(t, tt.data, content)
-					require.Equal(t, int64(tt.size), obj.Size())
+							// Verify the object was stored correctly
+							obj, err := store.Get(ctx, tt.key)
+							require.NoError(t, err)
+							defer obj.Body().Close()
+
+							content, err := io.ReadAll(obj.Body())
+							require.NoError(t, err)
+							require.Equal(t, tt.data, content)
+							require.Equal(t, int64(tt.size), obj.Size())
+						}
+					})
 				}
 			})
-		}
-	}
-}
 
-func TestGetOperations(t *testing.T) {
-	ctx := context.Background()
-	// Pre-populate test data
-	testData := []byte("0123456789abcdefghijklmnopqrstuvwxyz")
+			t.Run("get operations", func(t *testing.T) {
+				ctx := t.Context()
+				// Pre-populate test data
+				testData := []byte("0123456789abcdefghijklmnopqrstuvwxyz")
 
-	tests := []struct {
-		name      string
-		key       string
-		opts      []objectstore.GetOption
-		expected  []byte
-		expectErr error
-	}{
-		{
-			name:     "get existing object",
-			key:      "test-object",
-			expected: testData,
-		},
-		{
-			name:      "get non-existent object",
-			key:       "does-not-exist",
-			expectErr: objectstore.ErrNotExist,
-		},
-		{
-			name: "get with range - start only",
-			key:  "test-object",
-			opts: []objectstore.GetOption{
-				objectstore.WithRange(objectstore.Range{
-					Start: 10,
-					// End: nil means read to EOF
-				}),
-			},
-			expected: testData[10:],
-		},
-		{
-			name: "get with range - start and end",
-			key:  "test-object",
-			opts: []objectstore.GetOption{
-				objectstore.WithRange(objectstore.Range{
-					Start: 10,
-					End:   uint64Ptr(19), // 10 + 10 - 1 (inclusive)
-				}),
-			},
-			expected: testData[10:20],
-		},
-		{
-			name: "get with range - from beginning",
-			key:  "test-object",
-			opts: []objectstore.GetOption{
-				objectstore.WithRange(objectstore.Range{
-					Start: 0,
-					End:   uint64Ptr(4), // 0 + 5 - 1 (inclusive)
-				}),
-			},
-			expected: testData[0:5],
-		},
-		{
-			name: "get with range - near end",
-			key:  "test-object",
-			opts: []objectstore.GetOption{
-				objectstore.WithRange(objectstore.Range{
-					Start: 30,
-					End:   uint64Ptr(35), // 30 + 6 - 1 (inclusive)
-				}),
-			},
-			expected: testData[30:36],
-		},
-	}
+				tests := []struct {
+					name      string
+					key       string
+					opts      []objectstore.GetOption
+					expected  []byte
+					expectErr error
+				}{
+					{
+						name:     "get existing object",
+						key:      "test-object",
+						expected: testData,
+					},
+					{
+						name:      "get non-existent object",
+						key:       "does-not-exist",
+						expectErr: objectstore.ErrNotExist,
+					},
+					{
+						name: "get with range - start only",
+						key:  "test-object",
+						opts: []objectstore.GetOption{
+							objectstore.WithRange(objectstore.Range{
+								Start: 10,
+								// End: nil means read to EOF
+							}),
+						},
+						expected: testData[10:],
+					},
+					{
+						name: "get with range - start and end",
+						key:  "test-object",
+						opts: []objectstore.GetOption{
+							objectstore.WithRange(objectstore.Range{
+								Start: 10,
+								End:   uint64Ptr(19), // 10 + 10 - 1 (inclusive)
+							}),
+						},
+						expected: testData[10:20],
+					},
+					{
+						name: "get with range - from beginning",
+						key:  "test-object",
+						opts: []objectstore.GetOption{
+							objectstore.WithRange(objectstore.Range{
+								Start: 0,
+								End:   uint64Ptr(4), // 0 + 5 - 1 (inclusive)
+							}),
+						},
+						expected: testData[0:5],
+					},
+					{
+						name: "get with range - near end",
+						key:  "test-object",
+						opts: []objectstore.GetOption{
+							objectstore.WithRange(objectstore.Range{
+								Start: 30,
+								End:   uint64Ptr(35), // 30 + 6 - 1 (inclusive)
+							}),
+						},
+						expected: testData[30:36],
+					},
+				}
 
-	for _, k := range storeKinds {
-		if k != LevelDB {
-			continue
-		}
-		store := makeStore(t, k)
-		err := store.Put(ctx, "test-object", uint64(len(testData)), bytes.NewReader(testData))
-		require.NoError(t, err)
+				err := store.Put(ctx, "test-object", uint64(len(testData)), bytes.NewReader(testData))
+				require.NoError(t, err)
 
-		for _, tt := range tests {
-			t.Run(fmt.Sprintf("%s_%s", k, tt.name), func(t *testing.T) {
-				obj, err := store.Get(ctx, tt.key, tt.opts...)
+				for _, tt := range tests {
+					t.Run(tt.name, func(t *testing.T) {
+						obj, err := store.Get(ctx, tt.key, tt.opts...)
 
-				if tt.expectErr != nil {
-					require.Error(t, err)
-					require.Equal(t, tt.expectErr, err)
-				} else {
-					require.NoError(t, err)
-					defer obj.Body().Close()
+						if tt.expectErr != nil {
+							require.Error(t, err)
+							require.ErrorIs(t, err, tt.expectErr)
+						} else {
+							require.NoError(t, err)
+							defer obj.Body().Close()
 
-					content, err := io.ReadAll(obj.Body())
-					require.NoError(t, err)
-					require.Equal(t, tt.expected, content)
+							content, err := io.ReadAll(obj.Body())
+							require.NoError(t, err)
+							require.Equal(t, tt.expected, content)
+							require.Equal(t, int64(len(testData)), obj.Size())
+						}
+					})
+				}
+			})
 
-					// For range requests, the size should reflect the range length
-					if len(tt.opts) > 0 {
-						require.Equal(t, int64(len(tt.expected)), obj.Size())
-					} else {
-						require.Equal(t, int64(len(testData)), obj.Size())
+			t.Run("concurrent operations", func(t *testing.T) {
+				ctx := t.Context()
+				numOperations := 10
+
+				t.Run("concurrent puts", func(t *testing.T) {
+					errCh := make(chan error, numOperations)
+
+					for i := 0; i < numOperations; i++ {
+						go func(index int) {
+							key := fmt.Sprintf("concurrent-key-%d", index)
+							data := []byte(fmt.Sprintf("data-%d", index))
+							err := store.Put(ctx, key, uint64(len(data)), bytes.NewReader(data))
+							errCh <- err
+						}(i)
 					}
-				}
+
+					for i := 0; i < numOperations; i++ {
+						require.NoError(t, <-errCh)
+					}
+				})
+
+				t.Run("concurrent gets", func(t *testing.T) {
+					type result struct {
+						data []byte
+						err  error
+					}
+					resultCh := make(chan result, numOperations)
+
+					for i := 0; i < numOperations; i++ {
+						go func(index int) {
+							key := fmt.Sprintf("concurrent-key-%d", index)
+							obj, err := store.Get(ctx, key)
+							if err != nil {
+								resultCh <- result{err: err}
+								return
+							}
+							defer obj.Body().Close()
+
+							data, err := io.ReadAll(obj.Body())
+							resultCh <- result{data: data, err: err}
+						}(i)
+					}
+
+					for i := 0; i < numOperations; i++ {
+						res := <-resultCh
+						require.NoError(t, res.err)
+						require.Contains(t, string(res.data), "data-")
+					}
+				})
 			})
-		}
-	}
-}
 
-func TestConcurrentOperations(t *testing.T) {
-	ctx := context.Background()
-	numOperations := 10
-	for _, k := range storeKinds {
-		store := makeStore(t, k)
+			t.Run("edge cases", func(t *testing.T) {
+				ctx := t.Context()
 
-		t.Run("concurrent puts", func(t *testing.T) {
-			errCh := make(chan error, numOperations)
-
-			for i := 0; i < numOperations; i++ {
-				go func(index int) {
-					key := fmt.Sprintf("concurrent-key-%d", index)
-					data := []byte(fmt.Sprintf("data-%d", index))
+				t.Run("put and get with unicode key", func(t *testing.T) {
+					if k == FlatFS {
+						fmt.Println("unicode keys unsupported by FlatFS")
+						t.SkipNow()
+					}
+					key := "unicode-key-测试-🚀"
+					data := []byte("unicode content")
 					err := store.Put(ctx, key, uint64(len(data)), bytes.NewReader(data))
-					errCh <- err
-				}(i)
-			}
+					require.NoError(t, err)
 
-			for i := 0; i < numOperations; i++ {
-				require.NoError(t, <-errCh)
-			}
-		})
-
-		t.Run("concurrent gets", func(t *testing.T) {
-			type result struct {
-				data []byte
-				err  error
-			}
-			resultCh := make(chan result, numOperations)
-
-			for i := 0; i < numOperations; i++ {
-				go func(index int) {
-					key := fmt.Sprintf("concurrent-key-%d", index)
 					obj, err := store.Get(ctx, key)
-					if err != nil {
-						resultCh <- result{err: err}
-						return
-					}
+					require.NoError(t, err)
 					defer obj.Body().Close()
 
-					data, err := io.ReadAll(obj.Body())
-					resultCh <- result{data: data, err: err}
-				}(i)
-			}
+					content, err := io.ReadAll(obj.Body())
+					require.NoError(t, err)
+					require.Equal(t, data, content)
+				})
 
-			for i := 0; i < numOperations; i++ {
-				res := <-resultCh
-				require.NoError(t, res.err)
-				require.Contains(t, string(res.data), "data-")
-			}
+				t.Run("put with context cancellation", func(t *testing.T) {
+					cancelCtx, cancel := context.WithCancel(ctx)
+					cancel() // Cancel immediately
+
+					err := store.Put(cancelCtx, "cancelled-key", 10, bytes.NewReader([]byte("test data")))
+					require.Error(t, err)
+				})
+
+				t.Run("put and delete", func(t *testing.T) {
+					key := "test"
+					data := []byte("test")
+					err := store.Put(ctx, key, uint64(len(data)), bytes.NewReader(data))
+					require.NoError(t, err)
+
+					obj, err := store.Get(ctx, key)
+					require.NoError(t, err)
+					defer obj.Body().Close()
+
+					content, err := io.ReadAll(obj.Body())
+					require.NoError(t, err)
+					require.Equal(t, data, content)
+
+					err = store.Delete(ctx, key)
+					require.NoError(t, err)
+
+					_, err = store.Get(ctx, key)
+					require.ErrorIs(t, err, objectstore.ErrNotExist)
+				})
+			})
 		})
 	}
-}
-
-func TestEdgeCases(t *testing.T) {
-	ctx := context.Background()
-
-	for _, k := range storeKinds {
-		store := makeStore(t, k)
-		t.Run("put and get with unicode key", func(t *testing.T) {
-			if k == FlatFS {
-				fmt.Println("unicode keys unsupported by FlatFS")
-				t.SkipNow()
-			}
-			key := "unicode-key-测试-🚀"
-			data := []byte("unicode content")
-			err := store.Put(ctx, key, uint64(len(data)), bytes.NewReader(data))
-			require.NoError(t, err)
-
-			obj, err := store.Get(ctx, key)
-			require.NoError(t, err)
-			defer obj.Body().Close()
-
-			content, err := io.ReadAll(obj.Body())
-			require.NoError(t, err)
-			require.Equal(t, data, content)
-		})
-
-		t.Run("put with context cancellation", func(t *testing.T) {
-			cancelCtx, cancel := context.WithCancel(ctx)
-			cancel() // Cancel immediately
-
-			err := store.Put(cancelCtx, "cancelled-key", 10, bytes.NewReader([]byte("test data")))
-			require.Error(t, err)
-		})
-
-		t.Run("put and delete", func(t *testing.T) {
-			key := "test"
-			data := []byte("test")
-			err := store.Put(ctx, key, uint64(len(data)), bytes.NewReader(data))
-			require.NoError(t, err)
-
-			obj, err := store.Get(ctx, key)
-			require.NoError(t, err)
-			defer obj.Body().Close()
-
-			content, err := io.ReadAll(obj.Body())
-			require.NoError(t, err)
-			require.Equal(t, data, content)
-
-			err = store.Delete(ctx, key)
-			require.NoError(t, err)
-
-			_, err = store.Get(ctx, key)
-			require.ErrorIs(t, err, objectstore.ErrNotExist)
-		})
-	}
-}
-
-var (
-	minioEndpoint string
-)
-
-func TestMain(m *testing.M) {
-	if runtime.GOOS == "darwin" {
-		fmt.Println("Skipping darwin tests, testcontainers not supported in CI")
-		os.Exit(0)
-	}
-	logging.SetDebugLogging()
-	ctx := context.Background()
-
-	req := testcontainers.ContainerRequest{
-		Image:        "minio/minio:latest",
-		ExposedPorts: []string{"9000/tcp"},
-		Env: map[string]string{
-			"MINIO_ACCESS_KEY": "minioadmin",
-			"MINIO_SECRET_KEY": "minioadmin",
-		},
-		Cmd:        []string{"server", "/data"},
-		WaitingFor: wait.ForHTTP("/minio/health/live").WithPort("9000"),
-	}
-
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
-	if err != nil {
-		panic(fmt.Sprintf("Failed to start MinIO container: %v", err))
-	}
-
-	host, err := container.Host(ctx)
-	if err != nil {
-		panic(fmt.Sprintf("Failed to get container host: %v", err))
-	}
-
-	port, err := container.MappedPort(ctx, "9000")
-	if err != nil {
-		panic(fmt.Sprintf("Failed to get container port: %v", err))
-	}
-
-	minioEndpoint = fmt.Sprintf("%s:%s", host, port.Port())
-
-	code := m.Run()
-
-	if err := container.Terminate(ctx); err != nil {
-		panic(fmt.Sprintf("Failed to terminate container: %v", err))
-	}
-
-	os.Exit(code)
 }
 
 func createLevelDBStore(t *testing.T) objectstore.Store {
@@ -402,8 +336,20 @@ func createLevelDBStore(t *testing.T) objectstore.Store {
 }
 
 func createMinioStore(t *testing.T) objectstore.Store {
+	// This test expects docker to be running in linux CI environments and fails if it's not
+	if testutil.IsRunningInCI(t) && runtime.GOOS == "linux" {
+		if !testutil.IsDockerAvailable(t) {
+			t.Fatalf("docker is expected in CI linux testing environments, but wasn't found")
+		}
+	}
+	// otherwise this test is running locally, skip it if docker isn't available
+	if !testutil.IsDockerAvailable(t) {
+		t.SkipNow()
+	}
+
+	endpoint := testutil.StartMinioContainer(t)
 	bucketName := uniqueBucketName(t.Name())
-	store, err := miniostore.New(minioEndpoint, bucketName, minio.Options{
+	store, err := miniostore.New(endpoint, bucketName, minio.Options{
 		Creds:  credentials.NewStaticV4("minioadmin", "minioadmin", ""),
 		Secure: false,
 	})


### PR DESCRIPTION
I noticed that in https://github.com/storacha/piri/pull/417#issuecomment-3923358455 we agreed to add deterministic prefix sharding but it was not added.

This PR adds a `Base32FlatFSKeyEncoder` which is a `Base32KeyEncoder` that also does the FlatFS NextToLast(2) sharding. It is now used by the S3 compatible blobstore.

To ensure it was working correctly I added a minio testcontainers backed S3 store to the tests at `pkg/store/blobstore/store_test.go` and found the minio store was not correctly raising a `ErrRangeNotSatisfiable` error.

I fixed this error but then noticed that the minio store was returning the size of the range-restricted data for `Object.Size()` not the _total_ size of the object. Both PDP and the `space/content/retrieve` handler require it to be the total size of the object not the ranged size.

I ran the tests at `pkg/store/blobstore/store_test.go` and they were failing. I noticed that they weren't running the tests on all implementations and that the tests were testing that the object returned by `Get` had a size equal to the range-restricted size. Again, this is incorrect and I had to change the leveldb and memory stores as well.

I believe the total size issue has not surfaced yet because all node operators are using the FlatFS store to store blobs, which _does_ report the total size of the object correctly.